### PR TITLE
Fix Raspberry Pi 5 GPIO service startup

### DIFF
--- a/file-monitor.service
+++ b/file-monitor.service
@@ -10,7 +10,7 @@ Type=simple
 User=gate-controller
 Group=gate-controller
 SupplementaryGroups=gpio
-WorkingDirectory=/opt/gate-controller-deploy/current
+WorkingDirectory=/var/lib/gate-controller
 EnvironmentFile=/etc/gate-controller.env
 Environment=PYTHONUNBUFFERED=1
 ExecStartPre=/opt/gate-controller-deploy/current/.venv/bin/python -c 'import sys; assert sys.version_info >= (3, 10), "gate-controller requires Python 3.10+"'

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -29,7 +29,7 @@ class SystemdTrustBoundaryTests(unittest.TestCase):
         self.assertEqual("gate-controller", service.get("Group"))
         self.assertEqual("0710", service.get("StateDirectoryMode"))
         self.assertEqual(
-            "/opt/gate-controller-deploy/current",
+            "/var/lib/gate-controller",
             service.get("WorkingDirectory"),
         )
         self.assertTrue(


### PR DESCRIPTION
## What changed

- run the managed gate service from `/var/lib/gate-controller`
- keep all executable and import paths pinned to the immutable release
- update the systemd trust-boundary regression test

## Root cause

`rpi-lgpio` creates a notification pipe in the process working directory. The managed service used the read-only release directory as its working directory, so its `ExecStartPre` relay safety check failed before startup on the Raspberry Pi 5.

## Validation

- regression test failed before the unit change and passes after it
- `git diff --check` passes
- the previous candidate ran all 240 tests successfully on the Raspberry Pi before activation reached this hardware-specific startup check
- local full-suite discovery is dependency-limited (`requests`, Pillow, and watchdog are not installed in the macOS interpreter); GitHub Actions and the Pi candidate environment provide the pinned runtime dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the application service working directory to `/var/lib/gate-controller` for improved deployment consistency.

* **Tests**
  * Updated deployment verification to reflect the new application service location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->