### PR TITLE
Pin managed service Python import path

### DIFF
--- a/file-monitor.service
+++ b/file-monitor.service
@@ -12,7 +12,7 @@ Group=gate-controller
 SupplementaryGroups=gpio
 WorkingDirectory=/var/lib/gate-controller
 EnvironmentFile=/etc/gate-controller.env
-Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONUNBUFFERED=1 PYTHONPATH=/opt/gate-controller-deploy/current
 ExecStartPre=/opt/gate-controller-deploy/current/.venv/bin/python -c 'import sys; assert sys.version_info >= (3, 10), "gate-controller requires Python 3.10+"'
 ExecStartPre=/opt/gate-controller-deploy/current/.venv/bin/python -m gate_controller.relay_safe
 ExecStart=/opt/gate-controller-deploy/current/.venv/bin/python -m gate_controller

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -32,6 +32,10 @@ class SystemdTrustBoundaryTests(unittest.TestCase):
             "/var/lib/gate-controller",
             service.get("WorkingDirectory"),
         )
+        self.assertIn(
+            "PYTHONPATH=/opt/gate-controller-deploy/current",
+            service.get("Environment", ""),
+        )
         self.assertTrue(
             service.get("ExecStart", "").startswith(
                 "/opt/gate-controller-deploy/current/"


### PR DESCRIPTION
## What changed

- set the managed service `PYTHONPATH` to the immutable active release
- assert the import path in the systemd trust-boundary regression test

## Root cause

After PR #33 moved the service working directory to writable state storage for Pi 5 `rpi-lgpio`, Python no longer discovered the repository's `gate_controller` package from the current directory. The package is intentionally run directly from the release rather than installed into the virtual environment.

## Validation

- regression assertion failed before the unit change and passes after it
- `git diff --check` passes
- both prior Pi candidate runs completed all 240 tests before the systemd activation check
- GitHub Actions will run the full pinned dependency matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-monitor service startup by ensuring the current release location is available to Python.
  * Preserved unbuffered Python output for timely service logging.

* **Tests**
  * Added deployment coverage to verify the service uses the expected Python path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->