### PR TITLE
Add bounded gate recognition telemetry

### DIFF
--- a/.superpowers/sdd/2026-08-15-pi-telemetry-v3/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-15-pi-telemetry-v3/final-fix-report.md
@@ -1,0 +1,72 @@
+# Pi Telemetry V3 Final Fix Report
+
+## Status
+
+Final review findings are fixed on `codex/telemetry-v3-producer` without changing camera-arrival timing, authorization, OCR, relay pulse, actuation, hold-open, credential exclusion, or offline retry behavior.
+
+- Malformed telemetry and telemetry row/outbox/commit rewrite failures return the recovered original V2 outbox payload. Delivery continues and logs only bounded audit tokens: `status=fallback_v2` with `reason=malformed` or `reason=rewrite_failed`.
+- Export rejects the live database, `-wal`, `-shm`, and `-journal` sidecars, resolved path aliases, symlinks, hardlinks, and aliases introduced while the temporary export is being written. The guard runs again immediately before `os.replace`.
+- Export uses a private SQLite backup in 16-page steps, aborts after 250 ms of continuous busy status, reads only the snapshot, and streams stable `(received_at, event_id)` keyset pages capped at 100 rows.
+- `frames[].status`, including `quality_unavailable`, now survives telemetry persistence, pending outbox promotion, attempt metadata updates, and JSON export.
+- Retention strips embedded telemetry and restores schema version 2 on aged completed outbox payloads in the same transaction that removes detailed telemetry. Decision/evidence fields are unchanged; pending and retry payloads are untouched.
+
+## TDD Evidence
+
+Baseline before test changes:
+
+```sh
+python3.12 -m unittest discover -s tests
+```
+
+Result: 297 passed, 1 skipped.
+
+The initial focused RED run exercised nine review cases and produced the expected missing-behavior failures: 12 failures and 3 errors, including suppressed delivery, dropped frame status, missing keyset API, retained completed telemetry, unsafe replacement, and live-database export. The bounded-busy test separately errored with `sqlite3.OperationalError: database is locked`; the commit-failure test separately errored instead of returning V2.
+
+Focused GREEN:
+
+```sh
+python3.12 -m unittest \
+  tests.test_outbox.OutboxWorkerTests.test_malformed_telemetry_falls_back_to_the_original_v2_delivery \
+  tests.test_outbox.OutboxWorkerTests.test_telemetry_rewrite_failure_falls_back_without_blocking_delivery \
+  tests.test_outbox.OutboxWorkerTests.test_telemetry_commit_failure_returns_the_recovered_v2_payload \
+  tests.test_store.LocalStoreTests.test_frame_quality_status_survives_persistence_and_outbox_attachment \
+  tests.test_store.LocalStoreTests.test_telemetry_pages_use_received_at_and_event_id_as_a_stable_keyset \
+  tests.test_store.LocalStoreTests.test_retention_removes_only_old_telemetry_with_completed_delivery \
+  tests.test_telemetry_export.TelemetryExportTests.test_json_export_is_bounded_by_since_and_redacts_unsafe_stored_fields \
+  tests.test_telemetry_export.TelemetryExportTests.test_export_rejects_database_sidecars_and_same_file_aliases \
+  tests.test_telemetry_export.TelemetryExportTests.test_output_is_rechecked_for_database_aliases_before_replace \
+  tests.test_telemetry_export.TelemetryExportTests.test_concurrent_snapshot_export_does_not_delay_an_actuation_claim \
+  tests.test_telemetry_export.TelemetryExportTests.test_snapshot_busy_wait_is_bounded
+```
+
+Result: 11 passed, 0 failed. The concurrent export is deliberately paused during snapshot-row serialization; a real actuation claim succeeds in under 250 ms while export remains paused. A continuously exclusive database lock makes snapshot creation fail in under one second with the bounded snapshot timeout.
+
+Broader store/outbox/export/processor/telemetry/actuation/relay regression run: 134 passed, 0 failed.
+
+Final verification:
+
+```sh
+python3.12 -m unittest discover -s tests
+python3.12 -m compileall -q gate_controller tests
+git diff --check
+```
+
+Result: 306 passed, 1 expected platform skip; compile and diff checks clean.
+
+## Commit And Files
+
+Implementation commit: `67e1cdb238f83a676ca0626481d7c8d9882cdd9e` (`fix: harden telemetry delivery and export`)
+
+- `gate_controller/store.py`
+- `gate_controller/telemetry_export.py`
+- `tests/test_outbox.py`
+- `tests/test_store.py`
+- `tests/test_telemetry_export.py`
+
+No network access, dependency installation, deployment, push, hardware relay tests, or subagents were used.
+
+## Follow-up And Concern
+
+The matching web consumer contract must accept and preserve the bounded `frames[].status` token, including `quality_unavailable`. The web repository was not edited in this task.
+
+Snapshot export intentionally favors gate availability: after 250 ms of continuous SQLite busy status it raises a retryable `TimeoutError` instead of waiting seconds behind pre-relay writes. The deterministic concurrency test proves lock isolation and the claim-time bound; it is not a Pi hardware throughput benchmark.

--- a/.superpowers/sdd/2026-08-15-pi-telemetry-v3/task-2-fix-1-report.md
+++ b/.superpowers/sdd/2026-08-15-pi-telemetry-v3/task-2-fix-1-report.md
@@ -1,0 +1,68 @@
+# Pi Telemetry V3 Task 2 Fix 1 Report
+
+## Review Findings Addressed
+
+- `decision_to_relay_ms` is marked from the real relay activation callback, before pulse sleep and SQLite finalization.
+- Trace creation, frame quality, trace marks, relay-boundary marks, outcome marks, and finish are best effort and cannot suppress a successful gate result.
+- Frame quality has its own serialized bounded `status`; OCR attempt status reports OCR only.
+- Direct nonduplicate skip/error paths create one terminal trace, while duplicate processing and duplicate direct skips create no second trace.
+- Processor content digests are reused by frame-quality measurement instead of hashing each frame twice.
+
+## TDD Follow-up
+
+The independent review added the missing duplicate-direct-skip regression first:
+
+```sh
+uv run --with pillow==12.3.0 --with requests==2.34.2 \
+  python -m unittest \
+  tests.test_processor.GateProcessorTests.test_duplicate_direct_skip_does_not_create_a_second_trace
+```
+
+RED result: 1 test failed because the duplicate returned `queue_coalesced` with a second trace instead of `duplicate_event` without telemetry.
+
+GREEN focused result:
+
+```sh
+uv run --with pillow==12.3.0 --with requests==2.34.2 \
+  python -m unittest \
+  tests.test_processor tests.test_telemetry tests.test_images tests.test_actuation tests.test_relay
+```
+
+Result: 89 passed, 0 failed.
+
+Full verification:
+
+```sh
+uv run --with pillow==12.3.0 --with requests==2.34.2 --with watchdog==6.0.0 \
+  python -m unittest discover -s tests
+```
+
+Result: 275 passed, 0 failed, 1 platform-specific skip.
+
+Static verification:
+
+```sh
+git diff --check
+```
+
+Result: clean.
+
+## Commits
+
+- Main review-fix implementation: `f8715f6`
+- Duplicate direct-skip follow-up: `1e60428`
+
+## Changed Files
+
+- `gate_controller/actuation.py`
+- `gate_controller/images.py`
+- `gate_controller/processor.py`
+- `gate_controller/relay.py`
+- `gate_controller/telemetry.py`
+- `tests/test_actuation.py`
+- `tests/test_images.py`
+- `tests/test_processor.py`
+- `tests/test_relay.py`
+- `tests/test_telemetry.py`
+
+The reproducible enabled-versus-disabled 100-event latency benchmark remains a Task 4 acceptance item; it is not claimed by this Task 2 report.

--- a/.superpowers/sdd/2026-08-15-pi-telemetry-v3/task-2-fix-2-report.md
+++ b/.superpowers/sdd/2026-08-15-pi-telemetry-v3/task-2-fix-2-report.md
@@ -1,0 +1,88 @@
+# Pi Telemetry V3 Task 2 Fix 2 Report
+
+## Review Finding Addressed
+
+- `ProcessingTrace` now anchors the wall-clock `received_at` boundary to its monotonic creation point and accepts the worker's monotonic `decision_started_at` boundary.
+- `capture_to_burst_ms` includes the upstream quiet window. `burst_to_ocr_ms` and `end_to_end_ms` include ranking, hashing, and frame-quality preprocessing.
+- Upstream intervals are bounded by the existing 600,000 ms duration limit. Only cross-clock skew up to 100 ms is clamped; invalid, non-finite, too-old, or inconsistent timestamps leave affected durations unavailable.
+- Upstream seeding runs through the existing best-effort trace wrapper. A seed failure disables telemetry without changing OCR, authorization, relay, or outbox behavior.
+- Duplicate checks still occur before trace creation. Direct nonduplicate skip paths still produce one terminal trace.
+
+## Strict TDD Evidence
+
+Focused upstream tests were written before implementation. After correcting a test-only missing `timedelta` import, the clean RED run was:
+
+```sh
+python3.12 -m unittest tests.test_telemetry tests.test_processor
+```
+
+Result: 62 tests ran with 4 expected failures and 4 expected errors. The trace did not yet expose `seed_upstream`; allow, timeout, and stale traces omitted the quiet window/preprocessing; and an injected seed exception did not yet suppress telemetry.
+
+The focused GREEN run covered eight new tests:
+
+```sh
+python3.12 -m unittest \
+  tests.test_telemetry.ProcessingTraceTests.test_upstream_boundaries_anchor_wall_capture_to_monotonic_burst \
+  tests.test_telemetry.ProcessingTraceTests.test_upstream_capture_clamps_only_small_cross_clock_skew \
+  tests.test_telemetry.ProcessingTraceTests.test_inconsistent_upstream_capture_is_unavailable_not_fabricated \
+  tests.test_telemetry.ProcessingTraceTests.test_invalid_upstream_timestamps_leave_all_derived_stages_unavailable \
+  tests.test_processor.GateProcessorTests.test_upstream_quiet_window_and_preprocessing_are_in_stage_durations \
+  tests.test_processor.GateProcessorTests.test_upstream_seed_failure_is_best_effort \
+  tests.test_processor.GateProcessorTests.test_preprocessing_timeout_retains_upstream_terminal_durations \
+  tests.test_processor.GateProcessorTests.test_preprocessing_stale_path_retains_upstream_terminal_durations
+```
+
+Result: 8 passed, 0 failed.
+
+The allow-path clock test advances through 500 ms of quiet-window time, 200 ms before processor entry, 300 ms of hashing, 100 ms of quality work, and 50 ms of OCR. It asserts exactly 500 ms capture-to-burst, 600 ms burst-to-OCR, 50 ms OCR, and 1,150 ms end-to-end, with one recognizer call and one relay call. Timeout and stale tests assert 4,600 ms and 6,200 ms terminal durations respectively, with no recognizer or relay calls.
+
+## Verification
+
+Broader focused regression commands passed:
+
+```sh
+python3.12 -m unittest tests.test_telemetry tests.test_worker tests.test_actuation tests.test_relay -v
+```
+
+Result: 68 passed, 0 failed.
+
+The processor suite, excluding only two concurrently added uncommitted Task 3 persistence tests, passed 47 tests. This covered existing allow, deny/no-match, OCR exception, timeout/stale, duplicate, direct-skip, relay, and outbox call-count behavior.
+
+The exact committed `d4f2a67` snapshot was exported to a temporary directory and given a clean full-suite run:
+
+```sh
+python3.12 -m unittest discover -s tests
+```
+
+Result: 283 passed, 0 failed, 1 platform-specific skip.
+
+The active worktree also contains unrelated, uncommitted Task 3 RED tests in `tests/test_main.py`, `tests/test_outbox.py`, `tests/test_processor.py`, `tests/test_store.py`, and `tests/test_telemetry_export.py`. Full discovery there ran 294 tests and failed only those not-yet-implemented Task 3 contracts (1 failure and 9 errors). Those Task 3 changes were not edited, staged, or committed for this fix; `tests/test_processor.py` contains separate committed round 2 hunks.
+
+Static verification:
+
+```sh
+python3.12 -m compileall -q gate_controller tests
+git show --check d4f2a67
+git diff --check
+```
+
+Result: all clean.
+
+## Self-review
+
+- Trace construction remains after both duplicate guards, preserving trace-free duplicate behavior.
+- The compatibility fallback still calls `mark_burst()` when no upstream decision boundary is supplied.
+- The direct-skip path seeds `received_at` when available and still emits one terminal trace.
+- No relay pulse, hold-open, actuation, authorization, OCR limit, stale inhibition, result, or wire-schema behavior changed.
+- No hardware relay tests or network/dependency installation were performed.
+
+The reproducible enabled-versus-disabled latency benchmark remains a Task 4 acceptance item. These deterministic tests prove accounting boundaries but do not establish the under-25 ms p95 overhead target.
+
+## Commit And Files
+
+Implementation commit: `d4f2a676c3ba926040dbd2948028b7376f7c4071` (`fix: seed telemetry from upstream timing`)
+
+- `gate_controller/processor.py`
+- `gate_controller/telemetry.py`
+- `tests/test_processor.py`
+- `tests/test_telemetry.py`

--- a/.superpowers/sdd/2026-08-15-pi-telemetry-v3/task-3-report.md
+++ b/.superpowers/sdd/2026-08-15-pi-telemetry-v3/task-3-report.md
@@ -1,0 +1,91 @@
+# Pi Telemetry V3 Task 3 Report
+
+## Scope
+
+Implemented best-effort post-terminal SQLite persistence, pending outbox V3 promotion,
+delivery-attempt metadata, completed-delivery retention, and private JSON/CSV export.
+No authorization, matching, cooldown, relay pulse, stale-image, or hold-open behavior was
+changed.
+
+## RED
+
+Command:
+
+```sh
+uv run --with pillow==12.3.0 --with requests==2.34.2 --with watchdog==6.0.0 \
+  python -m unittest tests.test_store tests.test_outbox tests.test_processor tests.test_main -v
+```
+
+Result: 105 tests run; 1 failure and 8 errors. The failures proved the missing SQLite
+table/API, V3 attachment and retention behavior, outbox attempt handling, processor
+attachment, and CLI dispatch.
+
+Command:
+
+```sh
+uv run --with pillow==12.3.0 --with requests==2.34.2 --with watchdog==6.0.0 \
+  python -m unittest tests.test_telemetry_export -v
+```
+
+Result: 1 loader error because `gate_controller.telemetry_export` did not exist.
+
+## GREEN
+
+Focused command:
+
+```sh
+uv run --with pillow==12.3.0 --with requests==2.34.2 --with watchdog==6.0.0 \
+  python -m unittest tests.test_store tests.test_outbox tests.test_telemetry_export \
+  tests.test_processor tests.test_main -v
+```
+
+Result: 109 tests passed.
+
+Full command:
+
+```sh
+uv run --with pillow==12.3.0 --with requests==2.34.2 --with watchdog==6.0.0 \
+  python -m unittest discover -s tests -v
+```
+
+Result: 297 tests passed; 1 platform-specific `flock` test skipped.
+
+Additional verification:
+
+```sh
+git diff --check
+python3 -m compileall -q gate_controller tests
+```
+
+Both commands exited successfully.
+
+## Commit
+
+Implementation commit: `df76075 feat: persist and export event telemetry`
+
+Changed files:
+
+- `gate_controller/__main__.py`
+- `gate_controller/outbox.py`
+- `gate_controller/processor.py`
+- `gate_controller/store.py`
+- `gate_controller/telemetry_export.py`
+- `tests/test_main.py`
+- `tests/test_outbox.py`
+- `tests/test_processor.py`
+- `tests/test_store.py`
+- `tests/test_telemetry_export.py`
+
+## Contract Notes
+
+- `event_telemetry` has one row per event and one owner per trace ID.
+- Identical attachment is idempotent; event or trace conflicts are rejected.
+- Telemetry attachment and pending outbox V3 promotion share one separate transaction
+  after the terminal gate event has committed.
+- Completed outbox payloads are never rewritten by attachment or retry operations.
+- Retry attempt/state is persisted immediately before send; successful completion and
+  local `delivered` state are committed together.
+- Retention runs at most hourly and deletes only telemetry older than 30 days whose
+  outbox delivery completed.
+- Export uses an explicit path, an allowlisted redacted contract, mode `0600`, fsync,
+  and atomic `os.replace`.

--- a/gate_controller/__main__.py
+++ b/gate_controller/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import ipaddress
 import logging
 import os
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -17,6 +18,7 @@ from .outbox import HttpOutboxSender, OutboxWorker
 from .processor import GateProcessor
 from .relay import PiRelayAdapter, RelayController
 from .store import LocalStore
+from .telemetry_export import export_telemetry
 from .worker import (
     DEFAULT_MAX_BURST_CANDIDATES, DEFAULT_MAX_CANDIDATE_BYTES,
     MAX_BURST_CANDIDATES, MAX_CANDIDATE_BYTES, run_worker,
@@ -30,6 +32,9 @@ def main() -> None:
         level=os.environ.get("GATE_LOG_LEVEL", "INFO"),
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
+    if len(sys.argv) > 1 and sys.argv[1] == "telemetry-export":
+        _run_telemetry_export(sys.argv[2:])
+        return
     parser = argparse.ArgumentParser(description="Watch completed gate-camera uploads")
     authorised_default, database_default = default_runtime_paths(os.environ)
     parser.add_argument("--directory", type=Path,
@@ -108,6 +113,32 @@ def main() -> None:
         max_burst_candidates=max_burst_candidates,
         max_candidate_bytes=max_candidate_bytes,
     )
+
+
+def _run_telemetry_export(arguments: list[str]) -> None:
+    _, database_default = default_runtime_paths(os.environ)
+    parser = argparse.ArgumentParser(description="Export local gate telemetry")
+    parser.add_argument("--database", type=Path, default=database_default)
+    parser.add_argument("--format", choices=("json", "csv"), required=True)
+    parser.add_argument("--since", type=_iso8601, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parsed = parser.parse_args(arguments)
+    export_telemetry(
+        LocalStore(parsed.database),
+        format=parsed.format,
+        since=parsed.since,
+        output=parsed.output,
+    )
+
+
+def _iso8601(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an ISO8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise argparse.ArgumentTypeError("must include a timezone")
+    return parsed.astimezone(timezone.utc)
 
 
 def build_background_workers(store, relay, *, environment=None, latest_image=None,

--- a/gate_controller/actuation.py
+++ b/gate_controller/actuation.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
@@ -22,7 +23,7 @@ class ActuationCoordinator:
 
     def actuate(self, event: GateEvent, *, outbox_payload: dict | None = None,
                 command_ack: tuple[str, datetime] | None = None,
-                pre_activation_inhibit=None) -> ActuationExecution:
+                pre_activation_inhibit=None, on_activation=None) -> ActuationExecution:
         key = event.idempotency_key
         if not key:
             raise ValueError("actuation events require an idempotency key")
@@ -96,18 +97,25 @@ class ActuationCoordinator:
                 return ActuationExecution(False, "actuation_inhibit_error", None, "failed",
                                           "actuation_inhibit_error")
             inhibition = None
-            if pre_activation_inhibit is None:
-                relay_result = self._relay.trigger(event.source, idempotency_key=key)
-            else:
+            relay_kwargs = {"idempotency_key": key}
+            if pre_activation_inhibit is not None:
                 def check_inhibition():
                     nonlocal inhibition
                     inhibition = pre_activation_inhibit()
                     return inhibition
 
-                relay_result = self._relay.trigger(
-                    event.source, idempotency_key=key,
-                    pre_activation_inhibit=check_inhibition,
-                )
+                relay_kwargs["pre_activation_inhibit"] = check_inhibition
+            if on_activation is not None and _accepts_keyword(
+                self._relay.trigger, "on_activation"
+            ):
+                def notify_activation():
+                    try:
+                        on_activation()
+                    except Exception:
+                        pass
+
+                relay_kwargs["on_activation"] = notify_activation
+            relay_result = self._relay.trigger(event.source, **relay_kwargs)
             if inhibition is None:
                 self._last_attempt_monotonic = self._monotonic_clock()
             finalized = GateEvent(
@@ -149,3 +157,14 @@ def _linux_boot_id() -> str | None:
     except OSError:
         return None
     return boot_id or None
+
+
+def _accepts_keyword(callable_object, keyword: str) -> bool:
+    try:
+        parameters = inspect.signature(callable_object).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == keyword or parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )

--- a/gate_controller/images.py
+++ b/gate_controller/images.py
@@ -5,9 +5,88 @@ from time import monotonic, sleep
 
 from PIL import Image, ImageFilter, ImageStat
 
+from .telemetry import FrameTelemetry
+
 
 MAX_IMAGE_PIXELS = 16_000_000
+QUALITY_SIZE = (320, 180)
+QUALITY_UNAVAILABLE_DIGEST = hashlib.sha256(b"quality_unavailable").hexdigest()
 Image.MAX_IMAGE_PIXELS = min(Image.MAX_IMAGE_PIXELS or MAX_IMAGE_PIXELS, MAX_IMAGE_PIXELS)
+
+
+def measure_frame_quality(path: Path) -> FrameTelemetry:
+    """Return bounded, downsampled quality proxies without exposing image paths."""
+    path = Path(path)
+    try:
+        digest = _content_digest(path)
+    except OSError:
+        digest = QUALITY_UNAVAILABLE_DIGEST
+
+    try:
+        if not _has_jpeg_signature(path):
+            raise ValueError("invalid image signature")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(path) as image:
+                if image.format != "JPEG":
+                    raise ValueError("invalid image format")
+                width, height = image.size
+                image.draft("L", QUALITY_SIZE)
+                image.load()
+                image.thumbnail(QUALITY_SIZE, Image.Resampling.BILINEAR)
+                grayscale = image.convert("L")
+
+        histogram = grayscale.histogram()
+        pixel_count = max(sum(histogram), 1)
+        brightness = sum(value * count for value, count in enumerate(histogram)) / (
+            255 * pixel_count
+        )
+        darkness = sum(histogram[:33]) / pixel_count
+        highlight_clipping = sum(histogram[240:]) / pixel_count
+        sharpness = _sharpness_proxy(grayscale)
+        return FrameTelemetry(
+            sequence=0,
+            digest=digest,
+            width=width,
+            height=height,
+            sharpness=sharpness,
+            brightness=brightness,
+            darkness=darkness,
+            highlight_clipping=highlight_clipping,
+        )
+    except (
+        OSError, ValueError, Image.DecompressionBombWarning, Image.DecompressionBombError,
+    ):
+        return FrameTelemetry(
+            sequence=0,
+            digest=digest,
+            width=1,
+            height=1,
+            sharpness=0.0,
+            brightness=0.0,
+            darkness=0.0,
+            highlight_clipping=0.0,
+            status="quality_unavailable",
+        )
+
+
+def _sharpness_proxy(grayscale: Image.Image) -> float:
+    if grayscale.width < 3 or grayscale.height < 3:
+        return 0.0
+    laplacian = grayscale.filter(ImageFilter.Kernel(
+        (3, 3),
+        (0, 1, 0, 1, -4, 1, 0, 1, 0),
+        scale=1,
+        offset=128,
+    ))
+    interior = laplacian.crop((1, 1, laplacian.width - 1, laplacian.height - 1))
+    histogram = interior.histogram()
+    pixel_count = max(sum(histogram), 1)
+    mean_deviation = sum(
+        abs(value - 128) * count for value, count in enumerate(histogram)
+    ) / pixel_count
+    return min(mean_deviation / 128, 1.0)
+
 
 def wait_until_readable(path: Path, timeout: float, poll_interval: float = 0.1) -> bool:
     """Wait for a complete, decodable image without treating partial uploads as valid."""

--- a/gate_controller/images.py
+++ b/gate_controller/images.py
@@ -14,13 +14,14 @@ QUALITY_UNAVAILABLE_DIGEST = hashlib.sha256(b"quality_unavailable").hexdigest()
 Image.MAX_IMAGE_PIXELS = min(Image.MAX_IMAGE_PIXELS or MAX_IMAGE_PIXELS, MAX_IMAGE_PIXELS)
 
 
-def measure_frame_quality(path: Path) -> FrameTelemetry:
+def measure_frame_quality(path: Path, *, digest: str | None = None) -> FrameTelemetry:
     """Return bounded, downsampled quality proxies without exposing image paths."""
     path = Path(path)
-    try:
-        digest = _content_digest(path)
-    except OSError:
-        digest = QUALITY_UNAVAILABLE_DIGEST
+    if digest is None:
+        try:
+            digest = _content_digest(path)
+        except OSError:
+            digest = QUALITY_UNAVAILABLE_DIGEST
 
     try:
         if not _has_jpeg_signature(path):

--- a/gate_controller/models.py
+++ b/gate_controller/models.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .telemetry import EventTelemetry
 
 
 @dataclass(frozen=True)
@@ -72,3 +78,4 @@ class ProcessingResult:
     reason: str
     event_id: int | None = None
     decision: MatchDecision | None = None
+    telemetry: EventTelemetry | None = None

--- a/gate_controller/outbox.py
+++ b/gate_controller/outbox.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import warnings
 from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
 from threading import Event
@@ -202,7 +203,8 @@ class OutboxWorker:
 
     def __init__(self, store, send: Callable[..., None], poll_interval: float = 5.0, *,
                  evidence_spool: EvidenceSpool | None = None,
-                 controller_id: str = "primary"):
+                 controller_id: str = "primary",
+                 clock: Callable[[], datetime] | None = None):
         self._store = store
         self._send = send
         self._poll_interval = poll_interval
@@ -210,6 +212,8 @@ class OutboxWorker:
             self._store.path.parent / "event-evidence"
         )
         self._controller_id = controller_id
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._last_retention_at: datetime | None = None
         try:
             self._store.bind_pending_outbox_controller(self._controller_id)
             self._evidence_spool.cleanup(self._store.pending_evidence_digests())
@@ -229,17 +233,29 @@ class OutboxWorker:
         return self._store.queue_outbox(event_id, self.prepare_payload())
 
     def run_once(self) -> int:
+        now = self._clock()
+        self._run_retention(now)
         completed = 0
-        for item_id, payload in self._store.pending_outbox_items():
+        for item_id, _queued_payload in self._store.pending_outbox_items():
             try:
+                payload = self._store.prepare_outbox_attempt(item_id, self._clock())
+                if payload is None:
+                    continue
                 image_digest = payload.get("image_sha256")
                 if image_digest is None:
                     self._send(payload)
                 else:
                     self._send(payload, self._evidence_spool.load(image_digest))
             except Exception:
+                try:
+                    self._store.mark_outbox_retry(item_id)
+                except Exception:
+                    pass
                 continue
-            self._store.complete_outbox_item(item_id)
+            try:
+                self._store.complete_outbox_item(item_id, self._clock())
+            except Exception:
+                continue
             if (
                 image_digest is not None
                 and image_digest not in self._store.pending_evidence_digests()
@@ -250,6 +266,18 @@ class OutboxWorker:
                     pass
             completed += 1
         return completed
+
+    def _run_retention(self, now: datetime) -> None:
+        if (
+            self._last_retention_at is not None
+            and now - self._last_retention_at < timedelta(hours=1)
+        ):
+            return
+        self._last_retention_at = now
+        try:
+            self._store.purge_delivered_telemetry(now - timedelta(days=30))
+        except Exception:
+            pass
 
     def run_forever(self, stop_event: Event) -> None:
         while not stop_event.is_set():

--- a/gate_controller/processor.py
+++ b/gate_controller/processor.py
@@ -55,7 +55,10 @@ class GateProcessor:
                     self._store.ensure_outbox(event_id, self._outbox_payload(paths))
             return ProcessingResult(False, self._store.actuation_claim_status(idempotency_key) or "duplicate_event")
         trace = self._new_trace()
-        trace.mark_burst()
+        if received_at is not None or decision_started_at is not None:
+            trace.seed_upstream(received_at, decision_started_at)
+        if decision_started_at is None:
+            trace.mark_burst()
         received_at = received_at or self._clock()
         now = self._clock()
         if self._decision_clock() - started >= self._decision_timeout:
@@ -225,6 +228,8 @@ class GateProcessor:
             )
         if trace is None:
             trace = self._new_trace()
+            if received_at is not None:
+                trace.seed_upstream(received_at, None)
             trace.mark_burst()
         else:
             trace = _BestEffortTrace.wrap(trace)
@@ -310,6 +315,11 @@ class _BestEffortTrace:
 
     def mark_burst(self) -> None:
         self._call("mark_burst")
+
+    def seed_upstream(
+        self, received_at: datetime | None, decision_started_at: float | None
+    ) -> None:
+        self._call("seed_upstream", received_at, decision_started_at)
 
     def add_frame(self, frame) -> None:
         self._call("add_frame", frame)

--- a/gate_controller/processor.py
+++ b/gate_controller/processor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import inspect
 from collections.abc import Iterable
@@ -41,8 +43,10 @@ class GateProcessor:
     def process(self, paths: Iterable[Path], received_at: datetime | None = None,
                 decision_started_at: float | None = None) -> ProcessingResult:
         started = self._decision_clock() if decision_started_at is None else decision_started_at
-        paths = _unique_content_paths(tuple(Path(path) for path in paths))
-        idempotency_key = _event_key(paths)
+        candidates = _unique_content_candidates(tuple(Path(path) for path in paths))
+        paths = tuple(path for path, _digest in candidates)
+        digests = tuple(digest for _path, digest in candidates)
+        idempotency_key = _event_key_from_digests(digests)
         if self._store.event_exists(idempotency_key):
             if self._outbox_enabled:
                 event_id = self._store.terminal_outcome(idempotency_key)
@@ -50,21 +54,27 @@ class GateProcessor:
                 if event_id is not None:
                     self._store.ensure_outbox(event_id, self._outbox_payload(paths))
             return ProcessingResult(False, self._store.actuation_claim_status(idempotency_key) or "duplicate_event")
-        trace = self._trace_factory(
-            monotonic_clock=self._telemetry_clock,
-            wall_clock=self._telemetry_wall_clock,
-        )
+        trace = self._new_trace()
         trace.mark_burst()
         received_at = received_at or self._clock()
         now = self._clock()
         if self._decision_clock() - started >= self._decision_timeout:
-            return self.record_skipped(paths, "decision_timeout", received_at, trace=trace)
+            return self.record_skipped(
+                paths, "decision_timeout", received_at, trace=trace,
+                idempotency_key=idempotency_key,
+            )
         if not _is_fresh(now, received_at, self._max_image_age):
-            return self.record_skipped(paths, "stale_burst", received_at, trace=trace)
+            return self.record_skipped(
+                paths, "stale_burst", received_at, trace=trace,
+                idempotency_key=idempotency_key,
+            )
         try:
             authorised = self._authorised()
         except Exception:
-            return self.record_skipped(paths, "authorisation_error", received_at, trace=trace)
+            return self.record_skipped(
+                paths, "authorisation_error", received_at, trace=trace,
+                idempotency_key=idempotency_key,
+            )
         observations = []
         saw_ocr_error = False
         decision = None
@@ -74,8 +84,15 @@ class GateProcessor:
             if remaining <= 0:
                 timed_out = True
                 break
-            frame_quality = replace(measure_frame_quality(path), sequence=sequence)
-            trace.add_frame(frame_quality)
+            try:
+                frame_quality = replace(
+                    measure_frame_quality(path, digest=digests[sequence]),
+                    sequence=sequence,
+                )
+            except Exception:
+                trace.disable()
+            else:
+                trace.add_frame(frame_quality)
             remaining = self._decision_timeout - (self._decision_clock() - started)
             if remaining <= 0:
                 timed_out = True
@@ -99,11 +116,7 @@ class GateProcessor:
                 continue
             trace.add_ocr_attempt(OcrAttemptTelemetry(
                 frame_sequence=sequence,
-                status=(
-                    frame_quality.status
-                    if frame_quality.status != "ok"
-                    else ("matched" if observation.plate else "no_plate")
-                ),
+                status="recognized" if observation.plate else "no_plate",
                 plate=observation.plate,
                 confidence=observation.confidence,
                 make=observation.make,
@@ -120,7 +133,10 @@ class GateProcessor:
             timed_out = True
         if decision is None:
             reason = "decision_timeout" if timed_out else ("ocr_error" if saw_ocr_error else "no_match")
-            return self.record_skipped(paths, reason, received_at, trace=trace)
+            return self.record_skipped(
+                paths, reason, received_at, trace=trace,
+                idempotency_key=idempotency_key,
+            )
         decision_at = self._clock()
         if timed_out:
             trace.mark_decision("denied", "decision_timeout")
@@ -179,12 +195,14 @@ class GateProcessor:
                 return "failed", "authorisation_revoked"
             return None
 
-        execution = self._coordinator.actuate(
-            event,
-            outbox_payload=outbox_payload,
-            pre_activation_inhibit=activation_inhibition,
-        )
-        trace.mark_actuation(*_actuation_telemetry(execution))
+        actuation_kwargs = {
+            "outbox_payload": outbox_payload,
+            "pre_activation_inhibit": activation_inhibition,
+        }
+        if _accepts_keyword(self._coordinator.actuate, "on_activation"):
+            actuation_kwargs["on_activation"] = trace.mark_relay_activation
+        execution = self._coordinator.actuate(event, **actuation_kwargs)
+        trace.set_actuation_outcome(*_actuation_telemetry(execution))
         return self._finish_result(
             trace,
             ProcessingResult(execution.opened, execution.reason, execution.event_id, decision),
@@ -192,23 +210,37 @@ class GateProcessor:
 
     def record_skipped(self, paths: Iterable[Path], reason: str,
                        received_at: datetime | None = None,
-                       trace: ProcessingTrace | None = None) -> ProcessingResult:
+                       trace: ProcessingTrace | _BestEffortTrace | None = None,
+                       idempotency_key: str | None = None) -> ProcessingResult:
         paths = tuple(Path(path) for path in paths)
-        if trace is not None:
-            trace.mark_decision("denied", reason)
+        if trace is None:
+            trace = self._new_trace()
+            trace.mark_burst()
+        else:
+            trace = _BestEffortTrace.wrap(trace)
+        trace.mark_decision("denied", reason)
         event = GateEvent(
-            source="ocr", reason=reason, opened=False, idempotency_key=_event_key(paths),
+            source="ocr", reason=reason, opened=False,
+            idempotency_key=idempotency_key or _event_key(paths),
             received_at=received_at or self._clock(), decision_at=self._clock(),
         )
         event_id = self._record(event, paths)
         result = ProcessingResult(False, reason, event_id)
-        if trace is None:
-            return result
         return self._finish_result(trace, result)
 
     @staticmethod
-    def _finish_result(trace: ProcessingTrace, result: ProcessingResult) -> ProcessingResult:
-        return replace(result, telemetry=trace.finish())
+    def _finish_result(
+        trace: _BestEffortTrace, result: ProcessingResult
+    ) -> ProcessingResult:
+        telemetry = trace.finish()
+        return result if telemetry is None else replace(result, telemetry=telemetry)
+
+    def _new_trace(self) -> _BestEffortTrace:
+        return _BestEffortTrace.create(
+            self._trace_factory,
+            monotonic_clock=self._telemetry_clock,
+            wall_clock=self._telemetry_wall_clock,
+        )
 
     def _record(self, event: GateEvent, paths: Iterable[Path] = ()) -> int:
         payload = self._outbox_payload(paths)
@@ -236,10 +268,71 @@ class GateProcessor:
         return self._recognizer.recognise(path, timeout=(connect, read))
 
 
+class _BestEffortTrace:
+    """Disable a trace after its first failure without affecting gate processing."""
+
+    def __init__(self, trace) -> None:
+        self._trace = trace
+
+    @classmethod
+    def create(cls, factory, **kwargs):
+        try:
+            trace = factory(**kwargs)
+        except Exception:
+            trace = None
+        return cls(trace)
+
+    @classmethod
+    def wrap(cls, trace):
+        return trace if isinstance(trace, cls) else cls(trace)
+
+    def disable(self) -> None:
+        self._trace = None
+
+    def _call(self, operation: str, *args, **kwargs):
+        if self._trace is None:
+            return None
+        try:
+            return getattr(self._trace, operation)(*args, **kwargs)
+        except Exception:
+            self.disable()
+            return None
+
+    def mark_burst(self) -> None:
+        self._call("mark_burst")
+
+    def add_frame(self, frame) -> None:
+        self._call("add_frame", frame)
+
+    def mark_ocr_start(self) -> None:
+        self._call("mark_ocr_start")
+
+    def add_ocr_attempt(self, attempt) -> None:
+        self._call("add_ocr_attempt", attempt)
+
+    def mark_decision(self, outcome: str, reason: str) -> None:
+        self._call("mark_decision", outcome, reason)
+
+    def mark_relay_activation(self) -> None:
+        self._call("mark_relay_activation")
+
+    def set_actuation_outcome(
+        self, claim: str, attempted: bool, relay_outcome: str
+    ) -> None:
+        self._call("set_actuation_outcome", claim, attempted, relay_outcome)
+
+    def finish(self):
+        return self._call("finish")
+
+
 def _event_key(paths: tuple[Path, ...]) -> str:
-    if not paths:
-        return hashlib.sha256(b"empty-burst").hexdigest()
-    return _content_digest(paths[0])
+    return _event_key_from_digests(
+        tuple(_content_digest(path) for path in paths[:1])
+    )
+
+
+def _event_key_from_digests(digests: tuple[str, ...]) -> str:
+    return digests[0] if digests else hashlib.sha256(b"empty-burst").hexdigest()
 
 
 def _content_digest(path: Path) -> str:
@@ -254,6 +347,10 @@ def _content_digest(path: Path) -> str:
 
 
 def _unique_content_paths(paths: tuple[Path, ...]) -> tuple[Path, ...]:
+    return tuple(path for path, _digest in _unique_content_candidates(paths))
+
+
+def _unique_content_candidates(paths: tuple[Path, ...]) -> tuple[tuple[Path, str], ...]:
     unique = []
     digests = set()
     for path in paths:
@@ -261,7 +358,7 @@ def _unique_content_paths(paths: tuple[Path, ...]) -> tuple[Path, ...]:
         if digest in digests:
             continue
         digests.add(digest)
-        unique.append(path)
+        unique.append((path, digest))
     return tuple(unique)
 
 
@@ -295,3 +392,14 @@ def _actuation_telemetry(execution) -> tuple[str, bool, str]:
     if execution.reason == "indeterminate_claim":
         return "claimed", True, "indeterminate"
     return "claimed", True, execution.reason
+
+
+def _accepts_keyword(callable_object, keyword: str) -> bool:
+    try:
+        parameters = inspect.signature(callable_object).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == keyword or parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )

--- a/gate_controller/processor.py
+++ b/gate_controller/processor.py
@@ -213,6 +213,16 @@ class GateProcessor:
                        trace: ProcessingTrace | _BestEffortTrace | None = None,
                        idempotency_key: str | None = None) -> ProcessingResult:
         paths = tuple(Path(path) for path in paths)
+        idempotency_key = idempotency_key or _event_key(paths)
+        if self._store.event_exists(idempotency_key):
+            event_id = self._store.event_id(idempotency_key)
+            if self._outbox_enabled and event_id is not None:
+                self._store.ensure_outbox(event_id, self._outbox_payload(paths))
+            return ProcessingResult(
+                False,
+                self._store.actuation_claim_status(idempotency_key) or "duplicate_event",
+                event_id,
+            )
         if trace is None:
             trace = self._new_trace()
             trace.mark_burst()
@@ -221,7 +231,7 @@ class GateProcessor:
         trace.mark_decision("denied", reason)
         event = GateEvent(
             source="ocr", reason=reason, opened=False,
-            idempotency_key=idempotency_key or _event_key(paths),
+            idempotency_key=idempotency_key,
             received_at=received_at or self._clock(), decision_at=self._clock(),
         )
         event_id = self._record(event, paths)

--- a/gate_controller/processor.py
+++ b/gate_controller/processor.py
@@ -1,13 +1,16 @@
 import hashlib
 import inspect
 from collections.abc import Iterable
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import monotonic
 
 from .actuation import ActuationCoordinator
+from .images import measure_frame_quality
 from .matching import decide_access, normalise_plate
 from .models import GateEvent, ProcessingResult
+from .telemetry import OcrAttemptTelemetry, ProcessingTrace
 
 
 MAX_OCR_FRAMES = 3
@@ -17,7 +20,8 @@ class GateProcessor:
     def __init__(self, recognizer, store, relay, authorised: Iterable[str],
                  cooldown: timedelta = timedelta(seconds=20), outbox=None, clock=None,
                  coordinator=None, max_image_age: timedelta = timedelta(seconds=8),
-                 decision_timeout: float = 4.0, decision_clock=None):
+                 decision_timeout: float = 4.0, decision_clock=None,
+                 telemetry_clock=None, telemetry_wall_clock=None, trace_factory=None):
         self._recognizer = recognizer
         self._store = store
         self._authorised = authorised if callable(authorised) else lambda: tuple(authorised)
@@ -27,6 +31,11 @@ class GateProcessor:
         self._max_image_age = max_image_age
         self._decision_timeout = decision_timeout
         self._decision_clock = decision_clock or monotonic
+        self._telemetry_clock = telemetry_clock or monotonic
+        self._telemetry_wall_clock = telemetry_wall_clock or (
+            lambda: datetime.now(timezone.utc)
+        )
+        self._trace_factory = trace_factory or ProcessingTrace
         self._coordinator = coordinator or ActuationCoordinator(store, relay, cooldown, self._clock)
 
     def process(self, paths: Iterable[Path], received_at: datetime | None = None,
@@ -41,30 +50,66 @@ class GateProcessor:
                 if event_id is not None:
                     self._store.ensure_outbox(event_id, self._outbox_payload(paths))
             return ProcessingResult(False, self._store.actuation_claim_status(idempotency_key) or "duplicate_event")
+        trace = self._trace_factory(
+            monotonic_clock=self._telemetry_clock,
+            wall_clock=self._telemetry_wall_clock,
+        )
+        trace.mark_burst()
         received_at = received_at or self._clock()
         now = self._clock()
         if self._decision_clock() - started >= self._decision_timeout:
-            return self.record_skipped(paths, "decision_timeout", received_at)
+            return self.record_skipped(paths, "decision_timeout", received_at, trace=trace)
         if not _is_fresh(now, received_at, self._max_image_age):
-            return self.record_skipped(paths, "stale_burst", received_at)
+            return self.record_skipped(paths, "stale_burst", received_at, trace=trace)
         try:
             authorised = self._authorised()
         except Exception:
-            return self.record_skipped(paths, "authorisation_error", received_at)
+            return self.record_skipped(paths, "authorisation_error", received_at, trace=trace)
         observations = []
         saw_ocr_error = False
         decision = None
         timed_out = False
-        for path in paths[:MAX_OCR_FRAMES]:
+        for sequence, path in enumerate(paths[:MAX_OCR_FRAMES]):
             remaining = self._decision_timeout - (self._decision_clock() - started)
             if remaining <= 0:
                 timed_out = True
                 break
+            frame_quality = replace(measure_frame_quality(path), sequence=sequence)
+            trace.add_frame(frame_quality)
+            remaining = self._decision_timeout - (self._decision_clock() - started)
+            if remaining <= 0:
+                timed_out = True
+                break
+            ocr_started = False
+
+            def mark_ocr_start():
+                nonlocal ocr_started
+                trace.mark_ocr_start()
+                ocr_started = True
+
             try:
-                observations.append(self._recognise(path, remaining))
+                observation = self._recognise(path, remaining, mark_ocr_start)
             except Exception:
+                if ocr_started:
+                    trace.add_ocr_attempt(OcrAttemptTelemetry(
+                        frame_sequence=sequence,
+                        status="ocr_error",
+                    ))
                 saw_ocr_error = True
                 continue
+            trace.add_ocr_attempt(OcrAttemptTelemetry(
+                frame_sequence=sequence,
+                status=(
+                    frame_quality.status
+                    if frame_quality.status != "ok"
+                    else ("matched" if observation.plate else "no_plate")
+                ),
+                plate=observation.plate,
+                confidence=observation.confidence,
+                make=observation.make,
+                colour=observation.colour,
+            ))
+            observations.append(observation)
             decision = decide_access(observations, authorised)
             if self._decision_clock() - started >= self._decision_timeout:
                 timed_out = True
@@ -75,38 +120,52 @@ class GateProcessor:
             timed_out = True
         if decision is None:
             reason = "decision_timeout" if timed_out else ("ocr_error" if saw_ocr_error else "no_match")
-            return self.record_skipped(paths, reason, received_at)
+            return self.record_skipped(paths, reason, received_at, trace=trace)
         decision_at = self._clock()
         if timed_out:
+            trace.mark_decision("denied", "decision_timeout")
             event = _denied_event(idempotency_key, received_at, decision_at, "decision_timeout",
                                   decision)
             event_id = self._record(event, paths)
-            return ProcessingResult(False, "decision_timeout", event_id, decision)
+            return self._finish_result(
+                trace, ProcessingResult(False, "decision_timeout", event_id, decision)
+            )
         if not _is_fresh(decision_at, received_at, self._max_image_age):
+            trace.mark_decision("denied", "stale_burst")
             event = _denied_event(idempotency_key, received_at, decision_at, "stale_burst",
                                   decision)
             event_id = self._record(event, paths)
-            return ProcessingResult(False, "stale_burst", event_id, decision)
+            return self._finish_result(
+                trace, ProcessingResult(False, "stale_burst", event_id, decision)
+            )
         event = GateEvent(
             source="ocr", reason=decision.reason, opened=False, idempotency_key=idempotency_key,
             received_at=received_at, decision_at=decision_at,
             authorised_plate=decision.authorised_plate, observed_plate=decision.observed_plate,
             ocr_confidence=decision.confidence,
         )
-        outbox_payload = self._outbox_payload(paths)
         if not decision.allowed:
             if saw_ocr_error:
                 event = _denied_event(idempotency_key, received_at, decision_at, "ocr_error",
                                       decision)
+            trace.mark_decision("denied", event.reason)
+        else:
+            trace.mark_decision("allowed", decision.reason)
+        outbox_payload = self._outbox_payload(paths)
+        if not decision.allowed:
             event_id = self._store.record_event_with_outbox(event, outbox_payload)
-            return ProcessingResult(False, event.reason, event_id, decision)
+            return self._finish_result(
+                trace, ProcessingResult(False, event.reason, event_id, decision)
+            )
         actuation_at = self._clock()
         if not _is_fresh(actuation_at, received_at, self._max_image_age):
             event = _denied_event(
                 idempotency_key, received_at, actuation_at, "stale_burst", decision
             )
             event_id = self._store.record_event_with_outbox(event, outbox_payload)
-            return ProcessingResult(False, "stale_burst", event_id, decision)
+            return self._finish_result(
+                trace, ProcessingResult(False, "stale_burst", event_id, decision)
+            )
         def activation_inhibition():
             if not _is_fresh(self._clock(), received_at, self._max_image_age):
                 return "failed", "stale_burst"
@@ -125,17 +184,31 @@ class GateProcessor:
             outbox_payload=outbox_payload,
             pre_activation_inhibit=activation_inhibition,
         )
-        return ProcessingResult(execution.opened, execution.reason, execution.event_id, decision)
+        trace.mark_actuation(*_actuation_telemetry(execution))
+        return self._finish_result(
+            trace,
+            ProcessingResult(execution.opened, execution.reason, execution.event_id, decision),
+        )
 
     def record_skipped(self, paths: Iterable[Path], reason: str,
-                       received_at: datetime | None = None) -> ProcessingResult:
+                       received_at: datetime | None = None,
+                       trace: ProcessingTrace | None = None) -> ProcessingResult:
         paths = tuple(Path(path) for path in paths)
+        if trace is not None:
+            trace.mark_decision("denied", reason)
         event = GateEvent(
             source="ocr", reason=reason, opened=False, idempotency_key=_event_key(paths),
             received_at=received_at or self._clock(), decision_at=self._clock(),
         )
         event_id = self._record(event, paths)
-        return ProcessingResult(False, reason, event_id)
+        result = ProcessingResult(False, reason, event_id)
+        if trace is None:
+            return result
+        return self._finish_result(trace, result)
+
+    @staticmethod
+    def _finish_result(trace: ProcessingTrace, result: ProcessingResult) -> ProcessingResult:
+        return replace(result, telemetry=trace.finish())
 
     def _record(self, event: GateEvent, paths: Iterable[Path] = ()) -> int:
         payload = self._outbox_payload(paths)
@@ -150,12 +223,16 @@ class GateProcessor:
             return {"event_id": None}
         return prepare_payload(paths[0] if paths else None)
 
-    def _recognise(self, path: Path, remaining: float):
+    def _recognise(self, path: Path, remaining: float, on_start=None):
         parameters = inspect.signature(self._recognizer.recognise).parameters
         if "timeout" not in parameters:
+            if on_start is not None:
+                on_start()
             return self._recognizer.recognise(path)
         connect = min(1.0, max(0.1, remaining / 3))
         read = min(2.0, max(0.1, remaining - connect))
+        if on_start is not None:
+            on_start()
         return self._recognizer.recognise(path, timeout=(connect, read))
 
 
@@ -204,3 +281,17 @@ def _is_fresh(now: datetime, received_at: datetime, max_age: timedelta) -> bool:
     except (TypeError, ValueError):
         return False
     return timedelta(0) <= age <= max_age
+
+
+def _actuation_telemetry(execution) -> tuple[str, bool, str]:
+    if execution.opened:
+        return "claimed", True, "activated"
+    if execution.reason == "cooldown":
+        return "cooldown", False, "not_attempted"
+    if execution.reason == "actuation_inhibit_error":
+        return "claim_error", False, "not_attempted"
+    if execution.reason in {"stale_burst", "authorisation_error", "authorisation_revoked"}:
+        return "claimed", False, "inhibited"
+    if execution.reason == "indeterminate_claim":
+        return "claimed", True, "indeterminate"
+    return "claimed", True, execution.reason

--- a/gate_controller/processor.py
+++ b/gate_controller/processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import logging
 from collections.abc import Iterable
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
@@ -243,12 +244,21 @@ class GateProcessor:
         result = ProcessingResult(False, reason, event_id)
         return self._finish_result(trace, result)
 
-    @staticmethod
     def _finish_result(
-        trace: _BestEffortTrace, result: ProcessingResult
+        self, trace: _BestEffortTrace, result: ProcessingResult
     ) -> ProcessingResult:
         telemetry = trace.finish()
-        return result if telemetry is None else replace(result, telemetry=telemetry)
+        if telemetry is None:
+            return result
+        completed = replace(result, telemetry=telemetry)
+        if result.event_id is not None:
+            try:
+                self._store.attach_event_telemetry(result.event_id, telemetry)
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "event_telemetry_attach status=persistence_failed"
+                )
+        return completed
 
     def _new_trace(self) -> _BestEffortTrace:
         return _BestEffortTrace.create(

--- a/gate_controller/relay.py
+++ b/gate_controller/relay.py
@@ -22,7 +22,7 @@ class RelayController:
         self._last_outcome_at = self._clock()
 
     def trigger(self, source: str, idempotency_key: str | None = None, *,
-                pre_activation_inhibit=None) -> RelayResult:
+                pre_activation_inhibit=None, on_activation=None) -> RelayResult:
         with self._lock:
             if self._latched:
                 self._record_outcome("relay_latched")
@@ -38,6 +38,11 @@ class RelayController:
             try:
                 self._relay.on()
                 activated_at = self._clock()
+                if on_activation is not None:
+                    try:
+                        on_activation()
+                    except Exception:
+                        pass
                 self._sleeper(self._pulse_seconds)
             except BaseException as error:
                 if not self._deenergize():

--- a/gate_controller/store.py
+++ b/gate_controller/store.py
@@ -5,6 +5,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .models import ActuationClaim, GateEvent, TerminalOutcome
+from .telemetry import EventTelemetry, MAX_DELIVERY_ATTEMPT, MAX_DURATION_MS
+
+
+_TELEMETRY_FRAME_KEYS = (
+    "sequence", "digest", "width", "height", "sharpness", "brightness",
+    "darkness", "highlight_clipping",
+)
+_TELEMETRY_OCR_KEYS = (
+    "frame_sequence", "duration_ms", "status", "plate", "confidence", "make", "colour",
+)
 
 
 class LocalStore:
@@ -267,6 +277,153 @@ class LocalStore:
             ).fetchall()
         return [(row[0], json.loads(row[1])) for row in rows]
 
+    def attach_event_telemetry(self, event_id: int, telemetry: EventTelemetry) -> bool:
+        """Attach one trace after the terminal event transaction has committed."""
+        payload = _telemetry_payload(telemetry)
+        encoded = _encode_json(payload)
+        created_at = _timestamp(datetime.now(timezone.utc))
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            if connection.execute(
+                "SELECT 1 FROM events WHERE id = ?", (event_id,)
+            ).fetchone() is None:
+                raise KeyError(f"unknown event {event_id}")
+            existing = connection.execute(
+                "SELECT trace_id, payload FROM event_telemetry WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+            inserted = existing is None
+            if existing is not None:
+                existing_payload = json.loads(existing[1])
+                if existing[0] != payload["trace_id"] or not _same_trace(
+                    existing_payload, payload
+                ):
+                    raise ValueError("event already has conflicting telemetry")
+                payload = existing_payload
+                encoded = _encode_json(payload)
+            else:
+                trace_owner = connection.execute(
+                    "SELECT event_id FROM event_telemetry WHERE trace_id = ?",
+                    (payload["trace_id"],),
+                ).fetchone()
+                if trace_owner is not None:
+                    raise ValueError("telemetry trace is already attached to another event")
+                connection.execute(
+                    """
+                    INSERT INTO event_telemetry (event_id, trace_id, payload, created_at)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (event_id, payload["trace_id"], encoded, created_at),
+                )
+            self._promote_pending_outbox(connection, event_id, payload)
+            connection.commit()
+            return inserted
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def event_telemetry(self, event_id: int) -> dict | None:
+        with closing(self._connect()) as connection:
+            row = connection.execute(
+                "SELECT payload FROM event_telemetry WHERE event_id = ?", (event_id,)
+            ).fetchone()
+        return json.loads(row[0]) if row is not None else None
+
+    def event_telemetry_rows(self, since: datetime) -> list[dict]:
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT e.id, e.received_at, e.decision_at, e.relay_activated_at,
+                       e.source, e.reason, e.opened, e.authorised_plate,
+                       e.observed_plate, e.ocr_confidence, t.created_at, t.payload
+                FROM event_telemetry AS t
+                JOIN events AS e ON e.id = t.event_id
+                WHERE e.received_at >= ?
+                ORDER BY e.received_at, e.id
+                """,
+                (_timestamp(since),),
+            ).fetchall()
+        keys = (
+            "event_id", "received_at", "decision_at", "relay_activated_at", "source",
+            "reason", "opened", "authorised_plate", "observed_plate", "ocr_confidence",
+            "telemetry_created_at", "telemetry",
+        )
+        exported = []
+        for row in rows:
+            item = dict(zip(keys, row))
+            item["opened"] = bool(item["opened"])
+            item["telemetry"] = json.loads(item["telemetry"])
+            exported.append(item)
+        return exported
+
+    def prepare_outbox_attempt(self, item_id: int,
+                               attempted_at: datetime | None = None) -> dict | None:
+        attempted_at = attempted_at or datetime.now(timezone.utc)
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT event_id, payload, created_at FROM outbox
+                WHERE id = ? AND completed_at IS NULL
+                """,
+                (item_id,),
+            ).fetchone()
+            if row is None:
+                connection.commit()
+                return None
+            event_id, payload_text, created_at = row
+            payload = json.loads(payload_text)
+            telemetry_row = connection.execute(
+                "SELECT payload FROM event_telemetry WHERE event_id = ?", (event_id,)
+            ).fetchone()
+            if telemetry_row is not None:
+                telemetry = json.loads(telemetry_row[0])
+                current_attempt = telemetry.get("delivery", {}).get("outbox_attempt", 0)
+                attempt = min(max(int(current_attempt), 0) + 1, MAX_DELIVERY_ATTEMPT)
+                telemetry["delivery"] = {"outbox_attempt": attempt, "state": "sending"}
+                queued_at = _parse_timestamp(created_at)
+                lag_ms = max(0, int((_as_utc(attempted_at) - queued_at).total_seconds() * 1000))
+                telemetry.setdefault("stage_durations", {})["delivery_lag_ms"] = min(
+                    lag_ms, MAX_DURATION_MS
+                )
+                self._write_telemetry_payload(connection, event_id, telemetry)
+                payload["schema_version"] = 3
+                payload["telemetry"] = telemetry
+                connection.execute(
+                    "UPDATE outbox SET payload = ? WHERE id = ? AND completed_at IS NULL",
+                    (_encode_json(payload), item_id),
+                )
+            connection.commit()
+            return payload
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def mark_outbox_retry(self, item_id: int) -> None:
+        self._set_outbox_delivery_state(item_id, "retry_pending")
+
+    def purge_delivered_telemetry(self, cutoff: datetime) -> int:
+        with closing(self._connect()) as connection, connection:
+            cursor = connection.execute(
+                """
+                DELETE FROM event_telemetry
+                WHERE created_at < ?
+                  AND EXISTS (
+                    SELECT 1 FROM outbox
+                    WHERE outbox.event_id = event_telemetry.event_id
+                      AND outbox.completed_at IS NOT NULL
+                  )
+                """,
+                (_timestamp(cutoff),),
+            )
+        return cursor.rowcount
+
     def pending_evidence_digests(self) -> set[str]:
         with closing(self._connect()) as connection:
             rows = connection.execute(
@@ -341,11 +498,80 @@ class LocalStore:
             connection.execute("DELETE FROM command_ack_outbox WHERE command_id = ?", (command_id,))
 
     def complete_outbox_item(self, item_id: int, completed_at: datetime | None = None) -> None:
-        with closing(self._connect()) as connection, connection:
+        self._set_outbox_delivery_state(
+            item_id, "delivered", completed_at or datetime.now(timezone.utc)
+        )
+
+    def _set_outbox_delivery_state(self, item_id: int, state: str,
+                                   completed_at: datetime | None = None) -> None:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT event_id, payload FROM outbox WHERE id = ? AND completed_at IS NULL",
+                (item_id,),
+            ).fetchone()
+            if row is None:
+                connection.commit()
+                return
+            event_id, payload_text = row
+            payload = json.loads(payload_text)
+            telemetry_row = connection.execute(
+                "SELECT payload FROM event_telemetry WHERE event_id = ?", (event_id,)
+            ).fetchone()
+            if telemetry_row is not None:
+                telemetry = json.loads(telemetry_row[0])
+                attempt = telemetry.get("delivery", {}).get("outbox_attempt", 0)
+                telemetry["delivery"] = {
+                    "outbox_attempt": min(max(int(attempt), 0), MAX_DELIVERY_ATTEMPT),
+                    "state": state,
+                }
+                self._write_telemetry_payload(connection, event_id, telemetry)
+                payload["schema_version"] = 3
+                payload["telemetry"] = telemetry
             connection.execute(
-                "UPDATE outbox SET completed_at = ? WHERE id = ?",
-                (_timestamp(completed_at or datetime.now(timezone.utc)), item_id),
+                """
+                UPDATE outbox SET payload = ?, completed_at = ?
+                WHERE id = ? AND completed_at IS NULL
+                """,
+                (
+                    _encode_json(payload),
+                    _timestamp(completed_at) if completed_at is not None else None,
+                    item_id,
+                ),
             )
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _write_telemetry_payload(connection: sqlite3.Connection, event_id: int,
+                                 telemetry: dict) -> None:
+        connection.execute(
+            "UPDATE event_telemetry SET payload = ? WHERE event_id = ?",
+            (_encode_json(telemetry), event_id),
+        )
+
+    @staticmethod
+    def _promote_pending_outbox(connection: sqlite3.Connection, event_id: int,
+                                telemetry: dict) -> None:
+        row = connection.execute(
+            "SELECT id, payload FROM outbox WHERE event_id = ? AND completed_at IS NULL",
+            (event_id,),
+        ).fetchone()
+        if row is None:
+            return
+        outbox_id, payload_text = row
+        payload = json.loads(payload_text)
+        payload["schema_version"] = 3
+        payload["telemetry"] = telemetry
+        connection.execute(
+            "UPDATE outbox SET payload = ? WHERE id = ? AND completed_at IS NULL",
+            (_encode_json(payload), outbox_id),
+        )
 
     def _event_id(self, idempotency_key: str) -> int | None:
         with closing(self._connect()) as connection:
@@ -501,9 +727,17 @@ class LocalStore:
                     command_id TEXT PRIMARY KEY, status TEXT NOT NULL,
                     detail TEXT, created_at TEXT NOT NULL
                 );
+                CREATE TABLE IF NOT EXISTS event_telemetry (
+                    event_id INTEGER PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+                    trace_id TEXT NOT NULL UNIQUE,
+                    payload TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
                 CREATE INDEX IF NOT EXISTS events_relay_cooldown ON events (opened, relay_activated_at);
                 CREATE INDEX IF NOT EXISTS events_received_cooldown ON events (opened, received_at);
                 CREATE UNIQUE INDEX IF NOT EXISTS outbox_one_per_event ON outbox (event_id);
+                CREATE INDEX IF NOT EXISTS event_telemetry_created_at
+                    ON event_telemetry (created_at);
             """)
             columns = {row[1] for row in connection.execute("PRAGMA table_info(actuation_claims)")}
             for name in (
@@ -692,6 +926,46 @@ def _decode_optional_json(encoded: str | None) -> dict | None:
 
 def _timestamp(value: datetime) -> str:
     return _as_utc(value).isoformat()
+
+
+def _encode_json(value: dict) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _telemetry_payload(telemetry: EventTelemetry) -> dict:
+    raw = telemetry.to_wire()
+    if raw.get("schema_version") != 3:
+        raise ValueError("telemetry must use schema version 3")
+    return {
+        "trace_id": raw["trace_id"],
+        "taxonomy_version": raw["taxonomy_version"],
+        "stage_durations": dict(raw["stage_durations"]),
+        "frames": [
+            {key: frame[key] for key in _TELEMETRY_FRAME_KEYS if key in frame}
+            for frame in raw["frames"]
+        ],
+        "ocr_attempts": [
+            {key: attempt[key] for key in _TELEMETRY_OCR_KEYS if key in attempt}
+            for attempt in raw["ocr_attempts"]
+        ],
+        "decision": dict(raw["decision"]),
+        "actuation": dict(raw["actuation"]),
+        "delivery": dict(raw["delivery"]),
+    }
+
+
+def _same_trace(left: dict, right: dict) -> bool:
+    left_immutable = dict(left)
+    right_immutable = dict(right)
+    left_immutable.pop("delivery", None)
+    right_immutable.pop("delivery", None)
+    left_durations = dict(left_immutable.get("stage_durations", {}))
+    right_durations = dict(right_immutable.get("stage_durations", {}))
+    left_durations.pop("delivery_lag_ms", None)
+    right_durations.pop("delivery_lag_ms", None)
+    left_immutable["stage_durations"] = left_durations
+    right_immutable["stage_durations"] = right_durations
+    return left_immutable == right_immutable
 
 
 def _optional_timestamp(value: datetime | None) -> str | None:

--- a/gate_controller/store.py
+++ b/gate_controller/store.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import sqlite3
+import time
 from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
@@ -10,11 +12,19 @@ from .telemetry import EventTelemetry, MAX_DELIVERY_ATTEMPT, MAX_DURATION_MS
 
 _TELEMETRY_FRAME_KEYS = (
     "sequence", "digest", "width", "height", "sharpness", "brightness",
-    "darkness", "highlight_clipping",
+    "darkness", "highlight_clipping", "status",
 )
 _TELEMETRY_OCR_KEYS = (
     "frame_sequence", "duration_ms", "status", "plate", "confidence", "make", "colour",
 )
+_MAX_TELEMETRY_PAGE_SIZE = 100
+_SNAPSHOT_PAGES_PER_STEP = 16
+_SNAPSHOT_BUSY_TIMEOUT_SECONDS = 0.25
+_LOGGER = logging.getLogger(__name__)
+
+
+class _MalformedTelemetry(ValueError):
+    pass
 
 
 class LocalStore:
@@ -333,36 +343,87 @@ class LocalStore:
         return json.loads(row[0]) if row is not None else None
 
     def event_telemetry_rows(self, since: datetime) -> list[dict]:
+        exported = []
+        after = None
+        while True:
+            page = self.event_telemetry_page(since, after=after)
+            if not page:
+                return exported
+            exported.extend(page)
+            after = (page[-1]["received_at"], page[-1]["event_id"])
+
+    def event_telemetry_page(
+        self,
+        since: datetime,
+        *,
+        after: tuple[str, int] | None = None,
+        limit: int = _MAX_TELEMETRY_PAGE_SIZE,
+    ) -> list[dict]:
+        try:
+            bounded_limit = min(max(int(limit), 1), _MAX_TELEMETRY_PAGE_SIZE)
+        except (TypeError, ValueError):
+            bounded_limit = _MAX_TELEMETRY_PAGE_SIZE
+        parameters: tuple[object, ...]
+        if after is None:
+            keyset = ""
+            parameters = (_timestamp(since), bounded_limit)
+        else:
+            received_at, event_id = after
+            keyset = """
+              AND (e.received_at > ? OR (e.received_at = ? AND e.id > ?))
+            """
+            parameters = (
+                _timestamp(since), received_at, received_at, int(event_id), bounded_limit,
+            )
         with closing(self._connect()) as connection:
             rows = connection.execute(
-                """
+                f"""
                 SELECT e.id, e.received_at, e.decision_at, e.relay_activated_at,
                        e.source, e.reason, e.opened, e.authorised_plate,
                        e.observed_plate, e.ocr_confidence, t.created_at, t.payload
                 FROM event_telemetry AS t
                 JOIN events AS e ON e.id = t.event_id
                 WHERE e.received_at >= ?
+                {keyset}
                 ORDER BY e.received_at, e.id
+                LIMIT ?
                 """,
-                (_timestamp(since),),
+                parameters,
             ).fetchall()
-        keys = (
-            "event_id", "received_at", "decision_at", "relay_activated_at", "source",
-            "reason", "opened", "authorised_plate", "observed_plate", "ocr_confidence",
-            "telemetry_created_at", "telemetry",
-        )
-        exported = []
-        for row in rows:
-            item = dict(zip(keys, row))
-            item["opened"] = bool(item["opened"])
-            item["telemetry"] = json.loads(item["telemetry"])
-            exported.append(item)
-        return exported
+        return [_event_telemetry_export_row(row) for row in rows]
+
+    def create_telemetry_snapshot(self, destination: Path) -> None:
+        """Copy the live database in short backup steps with bounded busy waits."""
+        destination = Path(destination)
+        busy_started_at = None
+
+        def check_busy(status: int, _remaining: int, _total: int) -> None:
+            nonlocal busy_started_at
+            if status not in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+                busy_started_at = None
+                return
+            now = time.monotonic()
+            busy_started_at = now if busy_started_at is None else busy_started_at
+            if now - busy_started_at >= _SNAPSHOT_BUSY_TIMEOUT_SECONDS:
+                raise TimeoutError("telemetry snapshot database remained busy")
+
+        source_uri = f"{self.path.resolve().as_uri()}?mode=ro"
+        with closing(sqlite3.connect(
+            source_uri, uri=True, timeout=0.05
+        )) as source, closing(sqlite3.connect(destination, timeout=0.05)) as snapshot:
+            source.execute("PRAGMA busy_timeout = 50")
+            source.backup(
+                snapshot,
+                pages=_SNAPSHOT_PAGES_PER_STEP,
+                progress=check_busy,
+                sleep=0.01,
+            )
 
     def prepare_outbox_attempt(self, item_id: int,
                                attempted_at: datetime | None = None) -> dict | None:
         attempted_at = attempted_at or datetime.now(timezone.utc)
         connection = self._connect()
+        fallback = None
         try:
             connection.execute("BEGIN IMMEDIATE")
             row = connection.execute(
@@ -377,30 +438,53 @@ class LocalStore:
                 return None
             event_id, payload_text, created_at = row
             payload = json.loads(payload_text)
+            fallback = _v2_outbox_payload(payload)
             telemetry_row = connection.execute(
                 "SELECT payload FROM event_telemetry WHERE event_id = ?", (event_id,)
             ).fetchone()
-            if telemetry_row is not None:
-                telemetry = json.loads(telemetry_row[0])
-                current_attempt = telemetry.get("delivery", {}).get("outbox_attempt", 0)
-                attempt = min(max(int(current_attempt), 0) + 1, MAX_DELIVERY_ATTEMPT)
+            if telemetry_row is None:
+                connection.commit()
+                return fallback
+            try:
+                telemetry = _decode_telemetry_payload(telemetry_row[0])
+                attempt = min(
+                    _telemetry_attempt(telemetry) + 1, MAX_DELIVERY_ATTEMPT
+                )
                 telemetry["delivery"] = {"outbox_attempt": attempt, "state": "sending"}
                 queued_at = _parse_timestamp(created_at)
-                lag_ms = max(0, int((_as_utc(attempted_at) - queued_at).total_seconds() * 1000))
-                telemetry.setdefault("stage_durations", {})["delivery_lag_ms"] = min(
+                lag_ms = max(
+                    0,
+                    int((_as_utc(attempted_at) - queued_at).total_seconds() * 1000),
+                )
+                telemetry["stage_durations"]["delivery_lag_ms"] = min(
                     lag_ms, MAX_DURATION_MS
                 )
                 self._write_telemetry_payload(connection, event_id, telemetry)
+                payload = dict(fallback)
                 payload["schema_version"] = 3
                 payload["telemetry"] = telemetry
                 connection.execute(
                     "UPDATE outbox SET payload = ? WHERE id = ? AND completed_at IS NULL",
                     (_encode_json(payload), item_id),
                 )
+            except _MalformedTelemetry:
+                connection.rollback()
+                _log_telemetry_fallback("malformed")
+                return fallback
+            except Exception:
+                connection.rollback()
+                _log_telemetry_fallback("rewrite_failed")
+                return fallback
             connection.commit()
             return payload
         except Exception:
-            connection.rollback()
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            if fallback is not None:
+                _log_telemetry_fallback("rewrite_failed")
+                return fallback
             raise
         finally:
             connection.close()
@@ -409,20 +493,38 @@ class LocalStore:
         self._set_outbox_delivery_state(item_id, "retry_pending")
 
     def purge_delivered_telemetry(self, cutoff: datetime) -> int:
-        with closing(self._connect()) as connection, connection:
-            cursor = connection.execute(
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            rows = connection.execute(
                 """
-                DELETE FROM event_telemetry
-                WHERE created_at < ?
-                  AND EXISTS (
-                    SELECT 1 FROM outbox
-                    WHERE outbox.event_id = event_telemetry.event_id
-                      AND outbox.completed_at IS NOT NULL
-                  )
+                SELECT t.event_id, o.id, o.payload
+                FROM event_telemetry AS t
+                JOIN outbox AS o ON o.event_id = t.event_id
+                WHERE t.created_at < ? AND o.completed_at IS NOT NULL
                 """,
                 (_timestamp(cutoff),),
-            )
-        return cursor.rowcount
+            ).fetchall()
+            removed = 0
+            for event_id, outbox_id, payload_text in rows:
+                try:
+                    payload = _v2_outbox_payload(json.loads(payload_text))
+                except (TypeError, ValueError):
+                    continue
+                connection.execute(
+                    "UPDATE outbox SET payload = ? WHERE id = ? AND completed_at IS NOT NULL",
+                    (_encode_json(payload), outbox_id),
+                )
+                removed += connection.execute(
+                    "DELETE FROM event_telemetry WHERE event_id = ?", (event_id,)
+                ).rowcount
+            connection.commit()
+            return removed
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
 
     def pending_evidence_digests(self) -> set[str]:
         with closing(self._connect()) as connection:
@@ -516,19 +618,31 @@ class LocalStore:
                 return
             event_id, payload_text = row
             payload = json.loads(payload_text)
+            fallback = _v2_outbox_payload(payload)
+            payload = fallback
             telemetry_row = connection.execute(
                 "SELECT payload FROM event_telemetry WHERE event_id = ?", (event_id,)
             ).fetchone()
             if telemetry_row is not None:
-                telemetry = json.loads(telemetry_row[0])
-                attempt = telemetry.get("delivery", {}).get("outbox_attempt", 0)
-                telemetry["delivery"] = {
-                    "outbox_attempt": min(max(int(attempt), 0), MAX_DELIVERY_ATTEMPT),
-                    "state": state,
-                }
-                self._write_telemetry_payload(connection, event_id, telemetry)
-                payload["schema_version"] = 3
-                payload["telemetry"] = telemetry
+                connection.execute("SAVEPOINT telemetry_delivery_state")
+                try:
+                    telemetry = _decode_telemetry_payload(telemetry_row[0])
+                    telemetry["delivery"] = {
+                        "outbox_attempt": _telemetry_attempt(telemetry),
+                        "state": state,
+                    }
+                    self._write_telemetry_payload(connection, event_id, telemetry)
+                    payload = dict(fallback)
+                    payload["schema_version"] = 3
+                    payload["telemetry"] = telemetry
+                except _MalformedTelemetry:
+                    connection.execute("ROLLBACK TO telemetry_delivery_state")
+                    _log_telemetry_fallback("malformed")
+                except Exception:
+                    connection.execute("ROLLBACK TO telemetry_delivery_state")
+                    _log_telemetry_fallback("rewrite_failed")
+                finally:
+                    connection.execute("RELEASE telemetry_delivery_state")
             connection.execute(
                 """
                 UPDATE outbox SET payload = ?, completed_at = ?
@@ -966,6 +1080,68 @@ def _same_trace(left: dict, right: dict) -> bool:
     left_immutable["stage_durations"] = left_durations
     right_immutable["stage_durations"] = right_durations
     return left_immutable == right_immutable
+
+
+def _event_telemetry_export_row(row: tuple) -> dict:
+    keys = (
+        "event_id", "received_at", "decision_at", "relay_activated_at", "source",
+        "reason", "opened", "authorised_plate", "observed_plate", "ocr_confidence",
+        "telemetry_created_at", "telemetry",
+    )
+    item = dict(zip(keys, row))
+    item["opened"] = bool(item["opened"])
+    try:
+        telemetry = json.loads(item["telemetry"])
+    except (TypeError, ValueError):
+        telemetry = {}
+    item["telemetry"] = telemetry if isinstance(telemetry, dict) else {}
+    return item
+
+
+def _v2_outbox_payload(payload: object) -> dict:
+    if not isinstance(payload, dict):
+        raise ValueError("outbox payload must be an object")
+    fallback = dict(payload)
+    fallback.pop("telemetry", None)
+    fallback["schema_version"] = 2
+    return fallback
+
+
+def _decode_telemetry_payload(encoded: object) -> dict:
+    try:
+        telemetry = json.loads(encoded)
+    except (TypeError, ValueError) as error:
+        raise _MalformedTelemetry("telemetry is not valid JSON") from error
+    if not isinstance(telemetry, dict):
+        raise _MalformedTelemetry("telemetry is not an object")
+    expected = {
+        "trace_id": str,
+        "taxonomy_version": int,
+        "stage_durations": dict,
+        "frames": list,
+        "ocr_attempts": list,
+        "decision": dict,
+        "actuation": dict,
+        "delivery": dict,
+    }
+    if any(not isinstance(telemetry.get(key), value_type)
+           for key, value_type in expected.items()):
+        raise _MalformedTelemetry("telemetry has an invalid bounded contract")
+    return telemetry
+
+
+def _telemetry_attempt(telemetry: dict) -> int:
+    try:
+        attempt = int(telemetry["delivery"].get("outbox_attempt", 0))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise _MalformedTelemetry("telemetry delivery attempt is invalid") from error
+    return min(max(attempt, 0), MAX_DELIVERY_ATTEMPT)
+
+
+def _log_telemetry_fallback(reason: str) -> None:
+    _LOGGER.warning(
+        "outbox_telemetry_enrichment status=fallback_v2 reason=%s", reason
+    )
 
 
 def _optional_timestamp(value: datetime | None) -> str | None:

--- a/gate_controller/store.py
+++ b/gate_controller/store.py
@@ -20,6 +20,7 @@ _TELEMETRY_OCR_KEYS = (
 _MAX_TELEMETRY_PAGE_SIZE = 100
 _SNAPSHOT_PAGES_PER_STEP = 16
 _SNAPSHOT_BUSY_TIMEOUT_SECONDS = 0.25
+_SNAPSHOT_BUSY_SLICE_MS = 10
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -394,29 +395,31 @@ class LocalStore:
 
     def create_telemetry_snapshot(self, destination: Path) -> None:
         """Copy the live database in short backup steps with bounded busy waits."""
+        deadline = time.monotonic() + _SNAPSHOT_BUSY_TIMEOUT_SECONDS
         destination = Path(destination)
-        busy_started_at = None
 
-        def check_busy(status: int, _remaining: int, _total: int) -> None:
-            nonlocal busy_started_at
-            if status not in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
-                busy_started_at = None
-                return
-            now = time.monotonic()
-            busy_started_at = now if busy_started_at is None else busy_started_at
-            if now - busy_started_at >= _SNAPSHOT_BUSY_TIMEOUT_SECONDS:
+        def apply_remaining_budget(connection: sqlite3.Connection) -> None:
+            remaining_ms = int(max(0.0, deadline - time.monotonic()) * 1_000)
+            if remaining_ms <= 0:
                 raise TimeoutError("telemetry snapshot database remained busy")
+            busy_timeout_ms = min(remaining_ms, _SNAPSHOT_BUSY_SLICE_MS)
+            connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+
+        def check_deadline(status: int, _remaining: int, _total: int) -> None:
+            if status == sqlite3.SQLITE_DONE:
+                return
+            apply_remaining_budget(source)
 
         source_uri = f"{self.path.resolve().as_uri()}?mode=ro"
         with closing(sqlite3.connect(
-            source_uri, uri=True, timeout=0.05
-        )) as source, closing(sqlite3.connect(destination, timeout=0.05)) as snapshot:
-            source.execute("PRAGMA busy_timeout = 50")
+            source_uri, uri=True, timeout=0
+        )) as source, closing(sqlite3.connect(destination, timeout=0)) as snapshot:
+            apply_remaining_budget(source)
             source.backup(
                 snapshot,
                 pages=_SNAPSHOT_PAGES_PER_STEP,
-                progress=check_busy,
-                sleep=0.01,
+                progress=check_deadline,
+                sleep=0,
             )
 
     def prepare_outbox_attempt(self, item_id: int,

--- a/gate_controller/telemetry.py
+++ b/gate_controller/telemetry.py
@@ -82,6 +82,10 @@ class FrameTelemetry:
     brightness: float
     darkness: float
     highlight_clipping: float
+    status: str = "ok"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", _token(self.status))
 
     def to_wire(self) -> dict[str, object] | None:
         if not isinstance(self.digest, str) or not _SHA256.fullmatch(self.digest):

--- a/gate_controller/telemetry.py
+++ b/gate_controller/telemetry.py
@@ -99,6 +99,7 @@ class FrameTelemetry:
             "brightness": _ratio(self.brightness),
             "darkness": _ratio(self.darkness),
             "highlight_clipping": _ratio(self.highlight_clipping),
+            "status": self.status,
         }
 
 
@@ -228,6 +229,7 @@ class ProcessingTrace:
         self._ocr_work_ms = 0.0
         self._decision: float | None = None
         self._actuation: float | None = None
+        self._actuation_details_marked = False
         self._finished: float | None = None
         self._frames: list[FrameTelemetry] = []
         self._ocr_attempts: list[OcrAttemptTelemetry] = []
@@ -273,11 +275,22 @@ class ProcessingTrace:
             self._decision_reason = reason
 
     def mark_actuation(self, claim: str, attempted: bool, relay_outcome: str) -> None:
+        """Backward-compatible combined activation and outcome marker."""
+        self.mark_relay_activation()
+        self.set_actuation_outcome(claim, attempted, relay_outcome)
+
+    def mark_relay_activation(self) -> None:
         if self._actuation is None:
             self._actuation = self._monotonic_clock()
+
+    def set_actuation_outcome(
+        self, claim: str, attempted: bool, relay_outcome: str
+    ) -> None:
+        if not self._actuation_details_marked:
             self._actuation_claim = claim
             self._actuation_attempted = attempted
             self._relay_outcome = relay_outcome
+            self._actuation_details_marked = True
 
     def finish(
         self,

--- a/gate_controller/telemetry.py
+++ b/gate_controller/telemetry.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
+from itertools import islice
 import math
 import re
 import time
@@ -100,8 +101,8 @@ class FrameTelemetry:
 @dataclass(frozen=True)
 class OcrAttemptTelemetry:
     frame_sequence: int
-    duration_ms: float
-    status: str
+    duration_ms: float = 0.0
+    status: str = "unknown"
     plate: str | None = None
     confidence: float | None = None
     make: str | None = None
@@ -158,8 +159,12 @@ class EventTelemetry:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "trace_id", _trace_id(self.trace_id))
-        object.__setattr__(self, "frames", tuple(self.frames))
-        object.__setattr__(self, "ocr_attempts", tuple(self.ocr_attempts))
+        object.__setattr__(self, "frames", tuple(islice(self.frames, MAX_ITEMS)))
+        object.__setattr__(
+            self,
+            "ocr_attempts",
+            tuple(islice(self.ocr_attempts, MAX_ITEMS)),
+        )
 
     def to_wire(self) -> dict[str, object]:
         frames: list[dict[str, object]] = []
@@ -213,8 +218,10 @@ class ProcessingTrace:
         self.trace_id = _trace_id(trace_id) if trace_id is not None else str(uuid4())
         self._captured = monotonic_clock()
         self._burst: float | None = None
-        self._first_ocr: float | None = None
-        self._last_ocr: float | None = None
+        self._first_ocr_start: float | None = None
+        self._pending_ocr_start: float | None = None
+        self._last_ocr_end: float | None = None
+        self._ocr_work_ms = 0.0
         self._decision: float | None = None
         self._actuation: float | None = None
         self._finished: float | None = None
@@ -225,6 +232,7 @@ class ProcessingTrace:
         self._actuation_claim = "not_requested"
         self._actuation_attempted = False
         self._relay_outcome = "not_attempted"
+        self._finished_telemetry: EventTelemetry | None = None
 
     def mark_burst(self) -> None:
         if self._burst is None:
@@ -234,14 +242,25 @@ class ProcessingTrace:
         if len(self._frames) < MAX_ITEMS:
             self._frames.append(frame)
 
+    def mark_ocr_start(self) -> None:
+        """Mark the start of the next OCR attempt before invoking OCR."""
+        if len(self._ocr_attempts) >= MAX_ITEMS or self._pending_ocr_start is not None:
+            return
+        self._pending_ocr_start = self._monotonic_clock()
+        if self._first_ocr_start is None:
+            self._first_ocr_start = self._pending_ocr_start
+
     def add_ocr_attempt(self, attempt: OcrAttemptTelemetry) -> None:
         if len(self._ocr_attempts) >= MAX_ITEMS:
             return
-        timestamp = self._monotonic_clock()
-        if self._first_ocr is None:
-            self._first_ocr = timestamp
-        self._last_ocr = timestamp
-        self._ocr_attempts.append(attempt)
+        if self._pending_ocr_start is None:
+            raise RuntimeError("mark_ocr_start must be called before add_ocr_attempt")
+        ended_at = self._monotonic_clock()
+        duration_ms = _elapsed(self._pending_ocr_start, ended_at) or 0.0
+        self._last_ocr_end = ended_at
+        self._pending_ocr_start = None
+        self._ocr_work_ms += duration_ms
+        self._ocr_attempts.append(replace(attempt, duration_ms=duration_ms))
 
     def mark_decision(self, outcome: str, reason: str) -> None:
         if self._decision is None:
@@ -263,17 +282,16 @@ class ProcessingTrace:
         delivery_state: str = "pending",
         delivery_lag_ms: float | None = None,
     ) -> EventTelemetry:
-        if self._finished is None:
-            self._finished = self._monotonic_clock()
-        return EventTelemetry(
+        if self._finished_telemetry is not None:
+            return self._finished_telemetry
+        self._finished = self._monotonic_clock()
+        self._finished_telemetry = EventTelemetry(
             trace_id=self.trace_id,
             stage_durations=StageDurations(
                 capture_to_burst_ms=_elapsed(self._captured, self._burst),
-                burst_to_ocr_ms=_elapsed(self._burst, self._first_ocr),
-                ocr_ms=sum(_duration(attempt.duration_ms) or 0 for attempt in self._ocr_attempts)
-                if self._ocr_attempts
-                else None,
-                decision_ms=_elapsed(self._last_ocr, self._decision),
+                burst_to_ocr_ms=_elapsed(self._burst, self._first_ocr_start),
+                ocr_ms=self._ocr_work_ms,
+                decision_ms=_elapsed(self._last_ocr_end, self._decision),
                 decision_to_relay_ms=_elapsed(self._decision, self._actuation),
                 end_to_end_ms=_elapsed(self._captured, self._finished),
                 delivery_lag_ms=delivery_lag_ms,
@@ -288,6 +306,7 @@ class ProcessingTrace:
             outbox_attempt=outbox_attempt,
             delivery_state=delivery_state,
         )
+        return self._finished_telemetry
 
 
 def _elapsed(start: float | None, end: float | None) -> float | None:

--- a/gate_controller/telemetry.py
+++ b/gate_controller/telemetry.py
@@ -1,0 +1,296 @@
+"""Bounded V3 telemetry payloads for gate event processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import math
+import re
+import time
+from typing import Callable, Iterable
+from uuid import UUID, uuid4
+
+
+MAX_DURATION_MS = 600_000
+MAX_ITEMS = 8
+MAX_STRING_LENGTH = 128
+MAX_DIMENSION = 16_384
+MAX_DELIVERY_ATTEMPT = 1_000
+
+_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SHA256 = re.compile(r"^[a-f0-9]{64}$")
+
+
+def _rounded_int(value: object, minimum: int, maximum: int, fallback: int) -> int:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    if not math.isfinite(number):
+        return fallback
+    return min(max(math.floor(number + 0.5), minimum), maximum)
+
+
+def _duration(value: object | None) -> int | None:
+    if value is None:
+        return None
+    return _rounded_int(value, 0, MAX_DURATION_MS, 0)
+
+
+def _ratio(value: object) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(number):
+        return 0.0
+    return min(max(number, 0.0), 1.0)
+
+
+def _token(value: object, fallback: str = "unknown") -> str:
+    if isinstance(value, str) and _TOKEN.fullmatch(value):
+        return value
+    return fallback
+
+
+def _optional_string(value: object | None) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return value[:MAX_STRING_LENGTH]
+
+
+def _trace_id(value: object) -> str:
+    if isinstance(value, str):
+        try:
+            parsed = UUID(value)
+        except ValueError:
+            pass
+        else:
+            if parsed.version is not None:
+                return str(parsed)
+    return str(uuid4())
+
+
+@dataclass(frozen=True)
+class FrameTelemetry:
+    sequence: int
+    digest: str
+    width: int
+    height: int
+    sharpness: float
+    brightness: float
+    darkness: float
+    highlight_clipping: float
+
+    def to_wire(self) -> dict[str, object] | None:
+        if not isinstance(self.digest, str) or not _SHA256.fullmatch(self.digest):
+            return None
+        return {
+            "sequence": _rounded_int(self.sequence, 0, MAX_ITEMS - 1, 0),
+            "digest": self.digest,
+            "width": _rounded_int(self.width, 1, MAX_DIMENSION, 1),
+            "height": _rounded_int(self.height, 1, MAX_DIMENSION, 1),
+            "sharpness": _ratio(self.sharpness),
+            "brightness": _ratio(self.brightness),
+            "darkness": _ratio(self.darkness),
+            "highlight_clipping": _ratio(self.highlight_clipping),
+        }
+
+
+@dataclass(frozen=True)
+class OcrAttemptTelemetry:
+    frame_sequence: int
+    duration_ms: float
+    status: str
+    plate: str | None = None
+    confidence: float | None = None
+    make: str | None = None
+    colour: str | None = None
+
+    def to_wire(self) -> dict[str, object]:
+        return {
+            "frame_sequence": _rounded_int(self.frame_sequence, 0, MAX_ITEMS - 1, 0),
+            "duration_ms": _duration(self.duration_ms) or 0,
+            "status": _token(self.status),
+            "plate": _optional_string(self.plate),
+            "confidence": None if self.confidence is None else _ratio(self.confidence),
+            "make": _optional_string(self.make),
+            "colour": _optional_string(self.colour),
+        }
+
+
+@dataclass(frozen=True)
+class StageDurations:
+    capture_to_burst_ms: float | None = None
+    burst_to_ocr_ms: float | None = None
+    ocr_ms: float | None = None
+    decision_ms: float | None = None
+    decision_to_relay_ms: float | None = None
+    end_to_end_ms: float | None = None
+    delivery_lag_ms: float | None = None
+
+    def to_wire(self) -> dict[str, int]:
+        values = (
+            ("capture_to_burst_ms", self.capture_to_burst_ms),
+            ("burst_to_ocr_ms", self.burst_to_ocr_ms),
+            ("ocr_ms", self.ocr_ms),
+            ("decision_ms", self.decision_ms),
+            ("decision_to_relay_ms", self.decision_to_relay_ms),
+            ("end_to_end_ms", self.end_to_end_ms),
+            ("delivery_lag_ms", self.delivery_lag_ms),
+        )
+        return {name: duration for name, value in values if (duration := _duration(value)) is not None}
+
+
+@dataclass(frozen=True)
+class EventTelemetry:
+    trace_id: str
+    stage_durations: StageDurations
+    frames: Iterable[FrameTelemetry]
+    ocr_attempts: Iterable[OcrAttemptTelemetry]
+    decision_outcome: str
+    decision_reason: str
+    actuation_claim: str
+    actuation_attempted: bool
+    relay_outcome: str
+    outbox_attempt: int
+    delivery_state: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "trace_id", _trace_id(self.trace_id))
+        object.__setattr__(self, "frames", tuple(self.frames))
+        object.__setattr__(self, "ocr_attempts", tuple(self.ocr_attempts))
+
+    def to_wire(self) -> dict[str, object]:
+        frames: list[dict[str, object]] = []
+        for frame in self.frames:
+            if len(frames) == MAX_ITEMS:
+                break
+            encoded = frame.to_wire()
+            if encoded is not None:
+                frames.append(encoded)
+
+        attempts = [attempt.to_wire() for attempt in self.ocr_attempts][:MAX_ITEMS]
+        return {
+            "schema_version": 3,
+            "trace_id": self.trace_id,
+            "taxonomy_version": 1,
+            "stage_durations": self.stage_durations.to_wire(),
+            "frames": frames,
+            "ocr_attempts": attempts,
+            "decision": {
+                "outcome": _token(self.decision_outcome),
+                "reason": _token(self.decision_reason),
+            },
+            "actuation": {
+                "claim": _token(self.actuation_claim),
+                "attempted": self.actuation_attempted
+                if isinstance(self.actuation_attempted, bool)
+                else False,
+                "relay_outcome": _token(self.relay_outcome),
+            },
+            "delivery": {
+                "outbox_attempt": _rounded_int(
+                    self.outbox_attempt, 0, MAX_DELIVERY_ATTEMPT, 0
+                ),
+                "state": _token(self.delivery_state),
+            },
+        }
+
+
+class ProcessingTrace:
+    """Collect a bounded processing trace using injected clocks when desired."""
+
+    def __init__(
+        self,
+        *,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        trace_id: str | None = None,
+    ) -> None:
+        self._monotonic_clock = monotonic_clock
+        self.captured_at = wall_clock()
+        self.trace_id = _trace_id(trace_id) if trace_id is not None else str(uuid4())
+        self._captured = monotonic_clock()
+        self._burst: float | None = None
+        self._first_ocr: float | None = None
+        self._last_ocr: float | None = None
+        self._decision: float | None = None
+        self._actuation: float | None = None
+        self._finished: float | None = None
+        self._frames: list[FrameTelemetry] = []
+        self._ocr_attempts: list[OcrAttemptTelemetry] = []
+        self._decision_outcome = "unknown"
+        self._decision_reason = "unknown"
+        self._actuation_claim = "not_requested"
+        self._actuation_attempted = False
+        self._relay_outcome = "not_attempted"
+
+    def mark_burst(self) -> None:
+        if self._burst is None:
+            self._burst = self._monotonic_clock()
+
+    def add_frame(self, frame: FrameTelemetry) -> None:
+        if len(self._frames) < MAX_ITEMS:
+            self._frames.append(frame)
+
+    def add_ocr_attempt(self, attempt: OcrAttemptTelemetry) -> None:
+        if len(self._ocr_attempts) >= MAX_ITEMS:
+            return
+        timestamp = self._monotonic_clock()
+        if self._first_ocr is None:
+            self._first_ocr = timestamp
+        self._last_ocr = timestamp
+        self._ocr_attempts.append(attempt)
+
+    def mark_decision(self, outcome: str, reason: str) -> None:
+        if self._decision is None:
+            self._decision = self._monotonic_clock()
+            self._decision_outcome = outcome
+            self._decision_reason = reason
+
+    def mark_actuation(self, claim: str, attempted: bool, relay_outcome: str) -> None:
+        if self._actuation is None:
+            self._actuation = self._monotonic_clock()
+            self._actuation_claim = claim
+            self._actuation_attempted = attempted
+            self._relay_outcome = relay_outcome
+
+    def finish(
+        self,
+        *,
+        outbox_attempt: int = 0,
+        delivery_state: str = "pending",
+        delivery_lag_ms: float | None = None,
+    ) -> EventTelemetry:
+        if self._finished is None:
+            self._finished = self._monotonic_clock()
+        return EventTelemetry(
+            trace_id=self.trace_id,
+            stage_durations=StageDurations(
+                capture_to_burst_ms=_elapsed(self._captured, self._burst),
+                burst_to_ocr_ms=_elapsed(self._burst, self._first_ocr),
+                ocr_ms=sum(_duration(attempt.duration_ms) or 0 for attempt in self._ocr_attempts)
+                if self._ocr_attempts
+                else None,
+                decision_ms=_elapsed(self._last_ocr, self._decision),
+                decision_to_relay_ms=_elapsed(self._decision, self._actuation),
+                end_to_end_ms=_elapsed(self._captured, self._finished),
+                delivery_lag_ms=delivery_lag_ms,
+            ),
+            frames=tuple(self._frames),
+            ocr_attempts=tuple(self._ocr_attempts),
+            decision_outcome=self._decision_outcome,
+            decision_reason=self._decision_reason,
+            actuation_claim=self._actuation_claim,
+            actuation_attempted=self._actuation_attempted,
+            relay_outcome=self._relay_outcome,
+            outbox_attempt=outbox_attempt,
+            delivery_state=delivery_state,
+        )
+
+
+def _elapsed(start: float | None, end: float | None) -> float | None:
+    if start is None or end is None:
+        return None
+    return max(0.0, (end - start) * 1_000)

--- a/gate_controller/telemetry.py
+++ b/gate_controller/telemetry.py
@@ -17,6 +17,8 @@ MAX_ITEMS = 8
 MAX_STRING_LENGTH = 128
 MAX_DIMENSION = 16_384
 MAX_DELIVERY_ATTEMPT = 1_000
+MAX_UPSTREAM_INTERVAL_SECONDS = MAX_DURATION_MS / 1_000
+MAX_CLOCK_SKEW_SECONDS = 0.1
 
 _TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _SHA256 = re.compile(r"^[a-f0-9]{64}$")
@@ -219,7 +221,8 @@ class ProcessingTrace:
         trace_id: str | None = None,
     ) -> None:
         self._monotonic_clock = monotonic_clock
-        self.captured_at = wall_clock()
+        self._wall_anchor = wall_clock()
+        self.captured_at = self._wall_anchor
         self.trace_id = _trace_id(trace_id) if trace_id is not None else str(uuid4())
         self._captured = monotonic_clock()
         self._burst: float | None = None
@@ -239,6 +242,31 @@ class ProcessingTrace:
         self._actuation_attempted = False
         self._relay_outcome = "not_attempted"
         self._finished_telemetry: EventTelemetry | None = None
+
+    def seed_upstream(
+        self,
+        received_at: datetime | None,
+        decision_started_at: float | None,
+    ) -> None:
+        """Anchor upstream wall and monotonic boundaries to this trace."""
+        capture = _wall_to_monotonic(
+            received_at, self._wall_anchor, self._captured
+        )
+        burst = _upstream_monotonic(decision_started_at, self._captured)
+
+        if received_at is not None or decision_started_at is not None:
+            self._captured = capture
+        if capture is not None:
+            self.captured_at = received_at
+        if decision_started_at is not None:
+            self._burst = burst
+
+        if capture is None or burst is None or capture <= burst:
+            return
+        if capture - burst <= MAX_CLOCK_SKEW_SECONDS:
+            self._captured = burst
+        else:
+            self._captured = None
 
     def mark_burst(self) -> None:
         if self._burst is None:
@@ -330,3 +358,36 @@ def _elapsed(start: float | None, end: float | None) -> float | None:
     if start is None or end is None:
         return None
     return max(0.0, (end - start) * 1_000)
+
+
+def _wall_to_monotonic(
+    received_at: datetime | None,
+    wall_anchor: datetime,
+    monotonic_anchor: float,
+) -> float | None:
+    if received_at is None:
+        return None
+    try:
+        age = (wall_anchor - received_at).total_seconds()
+    except (AttributeError, OverflowError, TypeError, ValueError):
+        return None
+    if not math.isfinite(age) or not math.isfinite(monotonic_anchor):
+        return None
+    if age < -MAX_CLOCK_SKEW_SECONDS or age > MAX_UPSTREAM_INTERVAL_SECONDS:
+        return None
+    return monotonic_anchor - max(age, 0.0)
+
+
+def _upstream_monotonic(value: object, anchor: float) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(timestamp) or not math.isfinite(anchor):
+        return None
+    offset = timestamp - anchor
+    if offset > MAX_CLOCK_SKEW_SECONDS or offset < -MAX_UPSTREAM_INTERVAL_SECONDS:
+        return None
+    return min(timestamp, anchor)

--- a/gate_controller/telemetry_export.py
+++ b/gate_controller/telemetry_export.py
@@ -9,6 +9,8 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
+from .store import LocalStore
+
 
 _TOP_LEVEL_KEYS = (
     "trace_id", "taxonomy_version", "stage_durations", "frames", "ocr_attempts",
@@ -21,7 +23,7 @@ _NESTED_KEYS = {
     ),
     "frames": (
         "sequence", "digest", "width", "height", "sharpness", "brightness",
-        "darkness", "highlight_clipping",
+        "darkness", "highlight_clipping", "status",
     ),
     "ocr_attempts": (
         "frame_sequence", "duration_ms", "status", "plate", "confidence", "make",
@@ -40,6 +42,8 @@ _CSV_FIELDS = (
     "actuation_claim", "actuation_attempted", "relay_outcome", "outbox_attempt",
     "delivery_state",
 )
+_EXPORT_PAGE_SIZE = 100
+_DATABASE_SIDECARS = ("", "-wal", "-shm", "-journal")
 
 
 def export_telemetry(store, *, format: str, since: datetime,
@@ -51,9 +55,32 @@ def export_telemetry(store, *, format: str, since: datetime,
     if since.tzinfo is None:
         raise ValueError("telemetry export since timestamp must include a timezone")
     output = Path(output)
-    rows = [_safe_row(row) for row in store.event_telemetry_rows(since)]
-    _atomic_write(output, lambda destination: _write(destination, format, rows))
-    return len(rows)
+    protected_paths = _database_paths(store.path)
+    _validate_output_path(output, protected_paths)
+    with tempfile.TemporaryDirectory(
+        prefix=".telemetry-snapshot-", dir=output.parent
+    ) as snapshot_directory:
+        snapshot_path = Path(snapshot_directory) / "telemetry.db"
+        store.create_telemetry_snapshot(snapshot_path)
+        snapshot = LocalStore(snapshot_path)
+        rows = _snapshot_rows(snapshot, since)
+        return _atomic_write(
+            output,
+            lambda destination: _write(destination, format, rows),
+            protected_paths,
+        )
+
+
+def _snapshot_rows(store: LocalStore, since: datetime):
+    after = None
+    while True:
+        page = store.event_telemetry_page(
+            since, after=after, limit=_EXPORT_PAGE_SIZE
+        )
+        if not page:
+            return
+        yield from page
+        after = (page[-1]["received_at"], page[-1]["event_id"])
 
 
 def _safe_row(row: dict) -> dict:
@@ -103,15 +130,24 @@ def _scalar(value: object) -> bool:
     return value is None or isinstance(value, (bool, int, float, str))
 
 
-def _write(destination, format: str, rows: list[dict]) -> None:
+def _write(destination, format: str, rows) -> int:
     if format == "json":
-        json.dump(rows, destination, indent=2, sort_keys=True)
-        destination.write("\n")
-        return
+        count = 0
+        destination.write("[")
+        for raw_row in rows:
+            destination.write("," if count else "")
+            destination.write("\n  ")
+            json.dump(_safe_row(raw_row), destination, sort_keys=True)
+            count += 1
+        destination.write("\n]\n" if count else "]\n")
+        return count
     writer = csv.DictWriter(destination, fieldnames=_CSV_FIELDS)
     writer.writeheader()
-    for row in rows:
-        writer.writerow(_csv_row(row))
+    count = 0
+    for raw_row in rows:
+        writer.writerow(_csv_row(_safe_row(raw_row)))
+        count += 1
+    return count
 
 
 def _csv_row(row: dict) -> dict:
@@ -138,7 +174,7 @@ def _csv_row(row: dict) -> dict:
     return flattened
 
 
-def _atomic_write(output: Path, write) -> None:
+def _atomic_write(output: Path, write, protected_paths: tuple[Path, ...]) -> int:
     parent = output.parent
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=".telemetry-", suffix=".tmp", dir=parent
@@ -148,16 +184,44 @@ def _atomic_write(output: Path, write) -> None:
         os.fchmod(descriptor, 0o600)
         with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as destination:
             descriptor = -1
-            write(destination)
+            count = write(destination)
             destination.flush()
             os.fsync(destination.fileno())
+        _validate_output_path(output, protected_paths)
         os.replace(temporary, output)
         output.chmod(0o600)
         _fsync_directory(parent)
+        return count
     finally:
         if descriptor >= 0:
             os.close(descriptor)
         temporary.unlink(missing_ok=True)
+
+
+def _database_paths(database: Path) -> tuple[Path, ...]:
+    absolute = Path(os.path.abspath(os.fspath(database)))
+    resolved = absolute.resolve(strict=False)
+    protected = {
+        Path(f"{base}{suffix}")
+        for base in (absolute, resolved)
+        for suffix in _DATABASE_SIDECARS
+    }
+    return tuple(protected)
+
+
+def _validate_output_path(output: Path, protected_paths: tuple[Path, ...]) -> None:
+    candidate = Path(os.path.abspath(os.fspath(output)))
+    resolved_candidate = candidate.resolve(strict=False)
+    for protected in protected_paths:
+        resolved_protected = protected.resolve(strict=False)
+        if candidate == protected or resolved_candidate == resolved_protected:
+            raise ValueError("telemetry output must not target the live database or sidecars")
+        try:
+            same_file = candidate.samefile(protected)
+        except OSError:
+            same_file = False
+        if same_file:
+            raise ValueError("telemetry output must not alias the live database or sidecars")
 
 
 def _fsync_directory(path: Path) -> None:

--- a/gate_controller/telemetry_export.py
+++ b/gate_controller/telemetry_export.py
@@ -1,0 +1,168 @@
+"""Private, atomic export of bounded local processing telemetry."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+
+_TOP_LEVEL_KEYS = (
+    "trace_id", "taxonomy_version", "stage_durations", "frames", "ocr_attempts",
+    "decision", "actuation", "delivery",
+)
+_NESTED_KEYS = {
+    "stage_durations": (
+        "capture_to_burst_ms", "burst_to_ocr_ms", "ocr_ms", "decision_ms",
+        "decision_to_relay_ms", "end_to_end_ms", "delivery_lag_ms",
+    ),
+    "frames": (
+        "sequence", "digest", "width", "height", "sharpness", "brightness",
+        "darkness", "highlight_clipping",
+    ),
+    "ocr_attempts": (
+        "frame_sequence", "duration_ms", "status", "plate", "confidence", "make",
+        "colour",
+    ),
+    "decision": ("outcome", "reason"),
+    "actuation": ("claim", "attempted", "relay_outcome"),
+    "delivery": ("outbox_attempt", "state"),
+}
+_CSV_FIELDS = (
+    "event_id", "received_at", "source", "reason", "opened", "observed_plate",
+    "authorised_plate", "ocr_confidence", "telemetry_created_at", "trace_id",
+    "taxonomy_version", "capture_to_burst_ms", "burst_to_ocr_ms", "ocr_ms",
+    "decision_ms", "decision_to_relay_ms", "end_to_end_ms", "delivery_lag_ms",
+    "frame_count", "ocr_attempt_count", "decision_outcome", "decision_reason",
+    "actuation_claim", "actuation_attempted", "relay_outcome", "outbox_attempt",
+    "delivery_state",
+)
+
+
+def export_telemetry(store, *, format: str, since: datetime,
+                     output: Path | None) -> int:
+    if output is None:
+        raise ValueError("an explicit telemetry export output path is required")
+    if format not in {"json", "csv"}:
+        raise ValueError("telemetry export format must be json or csv")
+    if since.tzinfo is None:
+        raise ValueError("telemetry export since timestamp must include a timezone")
+    output = Path(output)
+    rows = [_safe_row(row) for row in store.event_telemetry_rows(since)]
+    _atomic_write(output, lambda destination: _write(destination, format, rows))
+    return len(rows)
+
+
+def _safe_row(row: dict) -> dict:
+    return {
+        "event_id": row["event_id"],
+        "received_at": row["received_at"],
+        "decision_at": row["decision_at"],
+        "relay_activated_at": row["relay_activated_at"],
+        "source": row["source"],
+        "reason": row["reason"],
+        "opened": bool(row["opened"]),
+        "authorised_plate": row["authorised_plate"],
+        "observed_plate": row["observed_plate"],
+        "ocr_confidence": row["ocr_confidence"],
+        "telemetry_created_at": row["telemetry_created_at"],
+        "telemetry": _safe_telemetry(row["telemetry"]),
+    }
+
+
+def _safe_telemetry(value: object) -> dict:
+    telemetry = value if isinstance(value, dict) else {}
+    safe = {
+        key: telemetry[key]
+        for key in ("trace_id", "taxonomy_version")
+        if key in telemetry and _scalar(telemetry[key])
+    }
+    for key in ("stage_durations", "decision", "actuation", "delivery"):
+        nested = telemetry.get(key)
+        safe[key] = _allowlisted_dict(nested, _NESTED_KEYS[key])
+    for key in ("frames", "ocr_attempts"):
+        items = telemetry.get(key)
+        safe[key] = [
+            _allowlisted_dict(item, _NESTED_KEYS[key])
+            for item in items[:8]
+            if isinstance(item, dict)
+        ] if isinstance(items, list) else []
+    return {key: safe[key] for key in _TOP_LEVEL_KEYS if key in safe}
+
+
+def _allowlisted_dict(value: object, allowed: tuple[str, ...]) -> dict:
+    if not isinstance(value, dict):
+        return {}
+    return {key: value[key] for key in allowed if key in value and _scalar(value[key])}
+
+
+def _scalar(value: object) -> bool:
+    return value is None or isinstance(value, (bool, int, float, str))
+
+
+def _write(destination, format: str, rows: list[dict]) -> None:
+    if format == "json":
+        json.dump(rows, destination, indent=2, sort_keys=True)
+        destination.write("\n")
+        return
+    writer = csv.DictWriter(destination, fieldnames=_CSV_FIELDS)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(_csv_row(row))
+
+
+def _csv_row(row: dict) -> dict:
+    telemetry = row["telemetry"]
+    durations = telemetry.get("stage_durations", {})
+    decision = telemetry.get("decision", {})
+    actuation = telemetry.get("actuation", {})
+    delivery = telemetry.get("delivery", {})
+    flattened = {key: row.get(key) for key in _CSV_FIELDS if key in row}
+    flattened.update({key: durations.get(key) for key in _NESTED_KEYS["stage_durations"]})
+    flattened.update({
+        "trace_id": telemetry.get("trace_id"),
+        "taxonomy_version": telemetry.get("taxonomy_version"),
+        "frame_count": len(telemetry.get("frames", [])),
+        "ocr_attempt_count": len(telemetry.get("ocr_attempts", [])),
+        "decision_outcome": decision.get("outcome"),
+        "decision_reason": decision.get("reason"),
+        "actuation_claim": actuation.get("claim"),
+        "actuation_attempted": actuation.get("attempted"),
+        "relay_outcome": actuation.get("relay_outcome"),
+        "outbox_attempt": delivery.get("outbox_attempt"),
+        "delivery_state": delivery.get("state"),
+    })
+    return flattened
+
+
+def _atomic_write(output: Path, write) -> None:
+    parent = output.parent
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".telemetry-", suffix=".tmp", dir=parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as destination:
+            descriptor = -1
+            write(destination)
+            destination.flush()
+            os.fsync(destination.fileno())
+        os.replace(temporary, output)
+        output.chmod(0o600)
+        _fsync_directory(parent)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/tests/test_actuation.py
+++ b/tests/test_actuation.py
@@ -34,6 +34,41 @@ class FailingMarkStore(LocalStore):
 
 
 class ActuationCoordinatorTests(unittest.TestCase):
+    def test_forwards_activation_hook_without_delaying_finalization(self):
+        now = datetime(2026, 8, 14, 10, 0, tzinfo=timezone.utc)
+        calls = []
+
+        class CallbackRelay:
+            def trigger(self, source, idempotency_key=None, *, on_activation=None):
+                calls.append("relay")
+                on_activation()
+                return RelayResult(True, "activated", idempotency_key, now)
+
+        class FinalizationStore(LocalStore):
+            def finalize_actuation(self, *args, **kwargs):
+                calls.append("finalize")
+                return super().finalize_actuation(*args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as directory:
+            result = ActuationCoordinator(
+                FinalizationStore(Path(directory) / "gate.db"),
+                CallbackRelay(),
+                clock=lambda: now,
+            ).actuate(
+                GateEvent(
+                    source="ocr",
+                    reason="exact_match",
+                    opened=False,
+                    idempotency_key="ocr-1",
+                    received_at=now,
+                    decision_at=now,
+                ),
+                on_activation=lambda: calls.append("activation"),
+            )
+
+        self.assertTrue(result.opened)
+        self.assertEqual(calls, ["relay", "activation", "finalize"])
+
     def test_successful_finalization_durably_queues_the_command_ack_before_restart(self):
         now = datetime(2026, 8, 14, 10, 0, tzinfo=timezone.utc)
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -41,6 +41,18 @@ class ImageTests(unittest.TestCase):
                 self.assertGreaterEqual(metric, 0.0)
                 self.assertLessEqual(metric, 1.0)
 
+    def test_measure_frame_quality_reuses_a_precomputed_digest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            frame = Path(directory) / "frame.jpg"
+            Image.new("L", (16, 8), color=128).save(frame, format="JPEG")
+            digest = hashlib.sha256(frame.read_bytes()).hexdigest()
+
+            with patch("gate_controller.images._content_digest") as content_digest:
+                quality = image_tools.measure_frame_quality(frame, digest=digest)
+
+            self.assertEqual(quality.digest, digest)
+            content_digest.assert_not_called()
+
     def test_measure_frame_quality_downsamples_before_filtering_for_sharpness(self):
         with tempfile.TemporaryDirectory() as directory:
             frame = Path(directory) / "large.jpg"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,3 +1,4 @@
+import hashlib
 import tempfile
 import unittest
 from pathlib import Path
@@ -5,10 +6,70 @@ from unittest.mock import patch
 
 from PIL import Image
 
+import gate_controller.images as image_tools
 from gate_controller.images import rank_images, wait_until_readable
 
 
 class ImageTests(unittest.TestCase):
+    def _measure_frame_quality(self, path: Path):
+        measure = getattr(image_tools, "measure_frame_quality", None)
+        self.assertIsNotNone(measure, "measure_frame_quality is not implemented")
+        return measure(path)
+
+    def test_measure_frame_quality_reports_dimensions_and_bounded_luma_metrics(self):
+        with tempfile.TemporaryDirectory() as directory:
+            frame = Path(directory) / "split.jpg"
+            image = Image.new("L", (16, 8))
+            image.putdata([0 if x < 8 else 255 for _y in range(8) for x in range(16)])
+            image.save(frame, format="JPEG", quality=100, subsampling=0)
+
+            quality = self._measure_frame_quality(frame)
+
+            self.assertEqual(quality.sequence, 0)
+            self.assertEqual(quality.digest, hashlib.sha256(frame.read_bytes()).hexdigest())
+            self.assertEqual((quality.width, quality.height), (16, 8))
+            self.assertAlmostEqual(quality.brightness, 0.5, delta=0.01)
+            self.assertAlmostEqual(quality.darkness, 0.5, delta=0.01)
+            self.assertAlmostEqual(quality.highlight_clipping, 0.5, delta=0.01)
+            self.assertGreater(quality.sharpness, 0.0)
+            for metric in (
+                quality.sharpness,
+                quality.brightness,
+                quality.darkness,
+                quality.highlight_clipping,
+            ):
+                self.assertGreaterEqual(metric, 0.0)
+                self.assertLessEqual(metric, 1.0)
+
+    def test_measure_frame_quality_downsamples_before_filtering_for_sharpness(self):
+        with tempfile.TemporaryDirectory() as directory:
+            frame = Path(directory) / "large.jpg"
+            Image.new("L", (640, 360), color=128).save(frame, format="JPEG")
+            filtered_sizes = []
+            original_filter = Image.Image.filter
+
+            def record_filter(image, image_filter):
+                filtered_sizes.append(image.size)
+                return original_filter(image, image_filter)
+
+            with patch.object(Image.Image, "filter", autospec=True, side_effect=record_filter):
+                quality = self._measure_frame_quality(frame)
+
+            self.assertEqual((quality.width, quality.height), (640, 360))
+            self.assertEqual(filtered_sizes, [(320, 180)])
+
+    def test_measure_frame_quality_returns_a_redacted_status_for_invalid_images(self):
+        with tempfile.TemporaryDirectory() as directory:
+            frame = Path(directory) / "private-camera-frame.jpg"
+            frame.write_bytes(b"not a jpeg: exceptionally sensitive details")
+
+            quality = self._measure_frame_quality(frame)
+
+            self.assertRegex(quality.status, r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+            self.assertEqual(quality.status, "quality_unavailable")
+            self.assertNotIn(str(frame), quality.status)
+            self.assertNotIn("sensitive", quality.status)
+
     def test_rejects_non_jpeg_magic_without_invoking_pillow(self):
         with tempfile.TemporaryDirectory() as directory:
             disguised = Path(directory) / "disguised.jpg"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,25 @@ from gate_controller.store import LocalStore
 
 
 class MainConfigurationTests(unittest.TestCase):
+    def test_telemetry_export_does_not_require_ocr_token_or_touch_the_relay(self):
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "sys.argv",
+            [
+                "gate-controller", "telemetry-export", "--database", "gate.db",
+                "--format", "json", "--since", "2026-08-01T00:00:00Z",
+                "--output", "telemetry.json",
+            ],
+        ), patch.object(gate_main, "require_python_version"), patch.object(
+            gate_main, "LocalStore", return_value=object()
+        ) as create_store, patch.object(
+            gate_main, "export_telemetry", return_value=1, create=True
+        ) as export, patch.object(gate_main, "PiRelayAdapter") as relay:
+            gate_main.main()
+
+        create_store.assert_called_once_with(Path("gate.db"))
+        export.assert_called_once()
+        relay.assert_not_called()
+
     def test_main_forces_relay_safe_before_store_and_recovers_before_workers(self):
         calls = []
 

--- a/tests/test_outbox.py
+++ b/tests/test_outbox.py
@@ -137,6 +137,96 @@ class EvidenceSpoolTests(unittest.TestCase):
 
 
 class OutboxWorkerTests(unittest.TestCase):
+    def test_malformed_telemetry_falls_back_to_the_original_v2_delivery(self):
+        store, event_id = self._queued_store()
+        item_id = store.queue_outbox(event_id, {
+            "controller_id": "pi-front-gate",
+            "image_status": "unavailable_before_queue",
+        })
+        original_v2 = store.pending_outbox_items()[0][1]
+        store.attach_event_telemetry(event_id, _telemetry())
+        with closing(sqlite3.connect(store.path)) as connection, connection:
+            connection.execute(
+                "UPDATE event_telemetry SET payload = ? WHERE event_id = ?",
+                ("{malformed", event_id),
+            )
+        sent = []
+
+        with self.assertLogs("gate_controller.store", level="WARNING") as logs:
+            completed = OutboxWorker(store, send=sent.append).run_once()
+
+        self.assertEqual(completed, 1)
+        self.assertEqual(sent, [original_v2])
+        self.assertEqual(sent[0]["schema_version"], 2)
+        self.assertNotIn("telemetry", sent[0])
+        self.assertEqual(sent[0]["image_status"], "unavailable_before_queue")
+        self.assertEqual(store.pending_outbox_count(), 0)
+        self.assertTrue(any(
+            "outbox_telemetry_enrichment status=fallback_v2 reason=malformed"
+            in entry for entry in logs.output
+        ))
+        with closing(sqlite3.connect(store.path)) as connection:
+            saved = json.loads(connection.execute(
+                "SELECT payload FROM outbox WHERE id = ?", (item_id,)
+            ).fetchone()[0])
+        self.assertEqual(saved, original_v2)
+
+    def test_telemetry_rewrite_failure_falls_back_without_blocking_delivery(self):
+        store, event_id = self._queued_store()
+        store.queue_outbox(event_id, {"controller_id": "pi-front-gate"})
+        original_v2 = store.pending_outbox_items()[0][1]
+        store.attach_event_telemetry(event_id, _telemetry())
+        original_write = store._write_telemetry_payload
+        writes = 0
+
+        def fail_first_write(connection, target_event_id, telemetry):
+            nonlocal writes
+            writes += 1
+            if writes == 1:
+                raise sqlite3.OperationalError("telemetry rewrite failed")
+            return original_write(connection, target_event_id, telemetry)
+
+        sent = []
+        with mock.patch.object(
+            store, "_write_telemetry_payload", side_effect=fail_first_write
+        ), self.assertLogs("gate_controller.store", level="WARNING") as logs:
+            completed = OutboxWorker(store, send=sent.append).run_once()
+
+        self.assertEqual(completed, 1)
+        self.assertEqual(sent, [original_v2])
+        self.assertEqual(store.pending_outbox_count(), 0)
+        self.assertTrue(any(
+            "outbox_telemetry_enrichment status=fallback_v2 reason=rewrite_failed"
+            in entry for entry in logs.output
+        ))
+
+    def test_telemetry_commit_failure_returns_the_recovered_v2_payload(self):
+        store, event_id = self._queued_store()
+        item_id = store.queue_outbox(event_id, {"controller_id": "pi-front-gate"})
+        original_v2 = store.pending_outbox_items()[0][1]
+        store.attach_event_telemetry(event_id, _telemetry())
+        connection = store._connect()
+
+        class CommitFailingConnection:
+            def __getattr__(self, name):
+                return getattr(connection, name)
+
+            def commit(self):
+                raise sqlite3.OperationalError("telemetry commit failed")
+
+        with mock.patch.object(
+            store, "_connect", return_value=CommitFailingConnection()
+        ), self.assertLogs("gate_controller.store", level="WARNING") as logs:
+            payload = store.prepare_outbox_attempt(
+                item_id, datetime(2026, 8, 15, 10, 0, 1, tzinfo=timezone.utc)
+            )
+
+        self.assertEqual(payload, original_v2)
+        self.assertTrue(any(
+            "outbox_telemetry_enrichment status=fallback_v2 reason=rewrite_failed"
+            in entry for entry in logs.output
+        ))
+
     def test_attempt_metadata_is_persisted_before_each_send_and_completed_after_success(self):
         store, event_id = self._queued_store()
         item_id = store.queue_outbox(event_id, {"controller_id": "pi-front-gate"})

--- a/tests/test_outbox.py
+++ b/tests/test_outbox.py
@@ -6,7 +6,7 @@ import sqlite3
 import stat
 import tempfile
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -16,6 +16,18 @@ import gate_controller.outbox as outbox_module
 from gate_controller.models import GateEvent
 from gate_controller.outbox import EvidenceSpoolError, HttpOutboxSender, OutboxWorker
 from gate_controller.store import LocalStore
+from gate_controller.telemetry import EventTelemetry, StageDurations
+
+
+def _telemetry():
+    return EventTelemetry(
+        trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+        stage_durations=StageDurations(end_to_end_ms=125),
+        frames=(), ocr_attempts=(),
+        decision_outcome="allowed", decision_reason="exact_match",
+        actuation_claim="claimed", actuation_attempted=True,
+        relay_outcome="activated", outbox_attempt=0, delivery_state="pending",
+    )
 
 
 class EvidenceSpoolTests(unittest.TestCase):
@@ -125,6 +137,67 @@ class EvidenceSpoolTests(unittest.TestCase):
 
 
 class OutboxWorkerTests(unittest.TestCase):
+    def test_attempt_metadata_is_persisted_before_each_send_and_completed_after_success(self):
+        store, event_id = self._queued_store()
+        item_id = store.queue_outbox(event_id, {"controller_id": "pi-front-gate"})
+        store.attach_event_telemetry(event_id, _telemetry())
+        sent = []
+
+        def send(payload):
+            sent.append(payload)
+            if len(sent) == 1:
+                raise RuntimeError("offline")
+
+        worker = OutboxWorker(store, send=send)
+
+        self.assertEqual(worker.run_once(), 0)
+        self.assertEqual(sent[0]["telemetry"]["delivery"], {
+            "outbox_attempt": 1,
+            "state": "sending",
+        })
+        self.assertEqual(store.event_telemetry(event_id)["delivery"], {
+            "outbox_attempt": 1,
+            "state": "retry_pending",
+        })
+
+        self.assertEqual(worker.run_once(), 1)
+        self.assertEqual(sent[1]["telemetry"]["delivery"], {
+            "outbox_attempt": 2,
+            "state": "sending",
+        })
+        self.assertEqual(store.event_telemetry(event_id)["delivery"], {
+            "outbox_attempt": 2,
+            "state": "delivered",
+        })
+        with closing(sqlite3.connect(store.path)) as connection:
+            completed_at = connection.execute(
+                "SELECT completed_at FROM outbox WHERE id = ?", (item_id,)
+            ).fetchone()[0]
+        self.assertIsNotNone(completed_at)
+
+    def test_retention_runs_at_startup_then_no_more_than_hourly(self):
+        store, _ = self._queued_store()
+        calls = []
+        original = store.purge_delivered_telemetry
+
+        def record(cutoff):
+            calls.append(cutoff)
+            return original(cutoff)
+
+        store.purge_delivered_telemetry = record
+        now = [datetime(2026, 8, 16, 12, 0, tzinfo=timezone.utc)]
+        worker = OutboxWorker(store, send=lambda payload: None, clock=lambda: now[0])
+
+        worker.run_once()
+        now[0] += timedelta(minutes=59)
+        worker.run_once()
+        now[0] += timedelta(minutes=2)
+        worker.run_once()
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0], datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc))
+        self.assertEqual(calls[1], datetime(2026, 7, 17, 13, 1, tzinfo=timezone.utc))
+
     def test_prepares_an_immutable_evidence_reference_without_a_local_path(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -11,6 +11,7 @@ from gate_controller.processor import GateProcessor
 from gate_controller.store import LocalStore
 from gate_controller.authorisation import AuthorisedPlateCache
 from gate_controller.images import rank_images
+from gate_controller.telemetry import ProcessingTrace
 
 
 class StaticRecognizer:
@@ -43,6 +44,14 @@ class MutableClock:
 
     def __call__(self):
         return self.value
+
+
+class SequenceClock:
+    def __init__(self, values):
+        self.values = iter(values)
+
+    def __call__(self):
+        return next(self.values)
 
 
 class RecordingRelay:
@@ -102,6 +111,218 @@ class GateProcessorTests(unittest.TestCase):
             clock=clock or (lambda: datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)),
             **kwargs,
         )
+
+    def _jpeg(self, directory: str, name: str, colour: int = 128) -> Path:
+        path = Path(directory) / name
+        Image.new("L", (16, 8), color=colour).save(path, format="JPEG")
+        return path
+
+    def test_early_allow_traces_one_ocr_attempt_and_decision_to_relay_time(self):
+        trace_clock = SequenceClock((10.0, 10.01, 10.02, 10.07, 10.08, 10.11, 10.12))
+        recognizer = SequenceRecognizer([
+            PlateObservation("12D3456", 0.95, make="Ford", colour="Blue"),
+            TimeoutError("must not be called"),
+        ])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frames = (
+                self._jpeg(directory, "first.jpg", 32),
+                self._jpeg(directory, "second.jpg", 224),
+            )
+            result = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay(relay_calls),
+                recognizer,
+                telemetry_clock=trace_clock,
+            ).process(frames)
+
+        wire = result.telemetry.to_wire()
+        self.assertTrue(result.opened)
+        self.assertEqual(recognizer.calls, [frames[0]])
+        self.assertEqual(relay_calls, ["relay"])
+        self.assertEqual(wire["stage_durations"], {
+            "capture_to_burst_ms": 10,
+            "burst_to_ocr_ms": 10,
+            "ocr_ms": 50,
+            "decision_ms": 10,
+            "decision_to_relay_ms": 30,
+            "end_to_end_ms": 120,
+        })
+        self.assertEqual(len(wire["frames"]), 1)
+        self.assertEqual(wire["ocr_attempts"], [{
+            "frame_sequence": 0,
+            "duration_ms": 50,
+            "status": "matched",
+            "plate": "12D3456",
+            "confidence": 0.95,
+            "make": "Ford",
+            "colour": "Blue",
+        }])
+        self.assertEqual(wire["decision"], {"outcome": "allowed", "reason": "exact_match"})
+        self.assertEqual(wire["actuation"], {
+            "claim": "claimed",
+            "attempted": True,
+            "relay_outcome": "activated",
+        })
+
+    def test_denied_no_match_accumulates_completed_ocr_work_without_relay(self):
+        trace_clock = SequenceClock(
+            (20.0, 20.01, 20.02, 20.05, 20.06, 20.10, 20.11, 20.12)
+        )
+        recognizer = SequenceRecognizer([
+            PlateObservation(None, 0.0),
+            PlateObservation("NOPE", 0.8, make="Unknown", colour="Silver"),
+        ])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frames = (
+                self._jpeg(directory, "first.jpg", 64),
+                self._jpeg(directory, "second.jpg", 192),
+            )
+            result = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay(relay_calls),
+                recognizer,
+                telemetry_clock=trace_clock,
+            ).process(frames)
+
+        wire = result.telemetry.to_wire()
+        self.assertEqual(result.reason, "no_match")
+        self.assertEqual(recognizer.calls, list(frames))
+        self.assertEqual(relay_calls, [])
+        self.assertEqual(wire["stage_durations"]["ocr_ms"], 70)
+        self.assertEqual(wire["stage_durations"]["decision_ms"], 10)
+        self.assertNotIn("decision_to_relay_ms", wire["stage_durations"])
+        self.assertEqual(wire["decision"], {"outcome": "denied", "reason": "no_match"})
+        self.assertEqual(wire["ocr_attempts"][1]["make"], "Unknown")
+        self.assertEqual(wire["ocr_attempts"][1]["colour"], "Silver")
+
+    def test_ocr_exception_closes_the_started_attempt_without_leaking_details(self):
+        trace_clock = SequenceClock((30.0, 30.01, 30.02, 30.09, 30.10, 30.11))
+        recognizer = SequenceRecognizer([TimeoutError("secret host / private/path")])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "error.jpg")
+            result = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay(relay_calls),
+                recognizer,
+                telemetry_clock=trace_clock,
+            ).process((frame,))
+
+        wire = result.telemetry.to_wire()
+        self.assertEqual(result.reason, "ocr_error")
+        self.assertEqual(recognizer.calls, [frame])
+        self.assertEqual(relay_calls, [])
+        self.assertEqual(wire["stage_durations"]["ocr_ms"], 70)
+        self.assertEqual(wire["ocr_attempts"][0]["status"], "ocr_error")
+        self.assertNotIn("secret", str(wire))
+        self.assertNotIn("private/path", str(wire))
+
+    def test_quality_error_is_bounded_without_blocking_ocr_or_relay(self):
+        recognizer = SequenceRecognizer([PlateObservation("12D3456", 0.95)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = Path(directory) / "private-frame.jpg"
+            frame.write_bytes(b"not a jpeg: do not expose this payload")
+            result = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay(relay_calls),
+                recognizer,
+            ).process((frame,))
+
+        attempt = result.telemetry.to_wire()["ocr_attempts"][0]
+        self.assertTrue(result.opened)
+        self.assertEqual(recognizer.calls, [frame])
+        self.assertEqual(relay_calls, ["relay"])
+        self.assertEqual(attempt["status"], "quality_unavailable")
+        self.assertNotIn(str(frame), str(attempt))
+        self.assertNotIn("do not expose", str(attempt))
+
+    def test_timeout_after_ocr_returns_a_finished_denied_trace_without_relay(self):
+        decision_clock = MutableClock()
+
+        class LateRecognizer(SequenceRecognizer):
+            def recognise(self, path, timeout=None):
+                result = super().recognise(path)
+                decision_clock.value = 4.1
+                return result
+
+        trace_clock = SequenceClock((40.0, 40.01, 40.02, 40.08, 40.09, 40.10))
+        recognizer = LateRecognizer([PlateObservation("12D3456", 0.99)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "late.jpg")
+            result = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay(relay_calls),
+                recognizer,
+                decision_timeout=4.0,
+                decision_clock=decision_clock,
+                telemetry_clock=trace_clock,
+            ).process((frame,))
+
+        wire = result.telemetry.to_wire()
+        self.assertEqual(result.reason, "decision_timeout")
+        self.assertEqual(recognizer.calls, [frame])
+        self.assertEqual(relay_calls, [])
+        self.assertEqual(wire["decision"], {
+            "outcome": "denied",
+            "reason": "decision_timeout",
+        })
+        self.assertEqual(wire["ocr_attempts"][0]["duration_ms"], 60)
+
+    def test_stale_burst_has_zero_ocr_work_and_no_recognizer_or_relay_calls(self):
+        wall_now = datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)
+        trace_clock = SequenceClock((50.0, 50.01, 50.02, 50.03))
+        recognizer = SequenceRecognizer([PlateObservation("12D3456", 0.99)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "stale.jpg")
+            result = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay(relay_calls),
+                recognizer,
+                clock=lambda: wall_now,
+                max_image_age=timedelta(seconds=5),
+                telemetry_clock=trace_clock,
+            ).process((frame,), received_at=wall_now - timedelta(seconds=6))
+
+        wire = result.telemetry.to_wire()
+        self.assertEqual(result.reason, "stale_burst")
+        self.assertEqual(recognizer.calls, [])
+        self.assertEqual(relay_calls, [])
+        self.assertEqual(wire["stage_durations"]["ocr_ms"], 0)
+        self.assertEqual(wire["ocr_attempts"], [])
+        self.assertEqual(wire["decision"], {"outcome": "denied", "reason": "stale_burst"})
+
+    def test_duplicate_event_does_not_create_a_second_trace_or_call_hardware(self):
+        created_traces = []
+
+        def trace_factory(**kwargs):
+            trace = ProcessingTrace(**kwargs)
+            created_traces.append(trace)
+            return trace
+
+        recognizer = SequenceRecognizer([PlateObservation("12D3456", 0.95)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "duplicate.jpg")
+            processor = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay(relay_calls),
+                recognizer,
+                trace_factory=trace_factory,
+            )
+
+            first = processor.process((frame,))
+            duplicate = processor.process((frame,))
+
+        self.assertIsNotNone(first.telemetry)
+        self.assertIsNone(duplicate.telemetry)
+        self.assertEqual(len(created_traces), 1)
+        self.assertEqual(recognizer.calls, [frame])
+        self.assertEqual(relay_calls, ["relay"])
 
     def test_activates_relay_before_persisting_or_queuing_optional_work(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -119,6 +119,9 @@ class FailingTelemetryTrace:
     def mark_burst(self):
         return self._call("mark_burst")
 
+    def seed_upstream(self, received_at, decision_started_at):
+        return self._call("seed_upstream", received_at, decision_started_at)
+
     def add_frame(self, frame):
         return self._call("add_frame", frame)
 
@@ -212,6 +215,104 @@ class GateProcessorTests(unittest.TestCase):
             "attempted": True,
             "relay_outcome": "activated",
         })
+
+    def test_upstream_quiet_window_and_preprocessing_are_in_stage_durations(self):
+        captured_at = datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc)
+        wall = [captured_at]
+        monotonic_clock = MutableClock()
+        monotonic_clock.value = 100.0
+
+        def advance(seconds):
+            monotonic_clock.value += seconds
+            wall[0] += timedelta(seconds=seconds)
+
+        advance(0.5)
+        decision_started_at = monotonic_clock.value
+        advance(0.2)
+
+        original_digest = processor_module._content_digest
+        original_quality = processor_module.measure_frame_quality
+
+        def timed_digest(path):
+            advance(0.3)
+            return original_digest(path)
+
+        def timed_quality(path, **kwargs):
+            advance(0.1)
+            return original_quality(path, **kwargs)
+
+        class TimedRecognizer(SequenceRecognizer):
+            def recognise(self, path):
+                result = super().recognise(path)
+                advance(0.05)
+                return result
+
+        recognizer = TimedRecognizer([PlateObservation("12D3456", 0.95)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "upstream.jpg")
+            with patch(
+                "gate_controller.processor._content_digest", side_effect=timed_digest
+            ), patch(
+                "gate_controller.processor.measure_frame_quality", side_effect=timed_quality
+            ):
+                result = self._processor(
+                    LocalStore(Path(directory) / "gate.db"),
+                    RecordingRelay(relay_calls),
+                    recognizer,
+                    clock=lambda: wall[0],
+                    decision_clock=monotonic_clock,
+                    telemetry_clock=monotonic_clock,
+                    telemetry_wall_clock=lambda: wall[0],
+                ).process(
+                    (frame,),
+                    received_at=captured_at,
+                    decision_started_at=decision_started_at,
+                )
+
+        self.assertTrue(result.opened)
+        self.assertEqual(recognizer.calls, [frame])
+        self.assertEqual(relay_calls, ["relay"])
+        self.assertEqual(result.telemetry.to_wire()["stage_durations"], {
+            "capture_to_burst_ms": 500,
+            "burst_to_ocr_ms": 600,
+            "ocr_ms": 50,
+            "decision_ms": 0,
+            "decision_to_relay_ms": 0,
+            "end_to_end_ms": 1_150,
+        })
+
+    def test_upstream_seed_failure_is_best_effort(self):
+        captured_at = datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc)
+        monotonic_clock = MutableClock()
+        monotonic_clock.value = 10.5
+        recognizer = SequenceRecognizer([PlateObservation("12D3456", 0.95)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "seed-failure.jpg")
+            store = LocalStore(Path(directory) / "gate.db")
+            result = self._processor(
+                store,
+                RecordingRelay(relay_calls),
+                recognizer,
+                outbox=object(),
+                clock=lambda: captured_at + timedelta(seconds=0.5),
+                decision_clock=monotonic_clock,
+                telemetry_clock=monotonic_clock,
+                telemetry_wall_clock=lambda: captured_at + timedelta(seconds=0.5),
+                trace_factory=lambda **kwargs: FailingTelemetryTrace(
+                    "seed_upstream", **kwargs
+                ),
+            ).process(
+                (frame,), received_at=captured_at, decision_started_at=10.5
+            )
+
+            self.assertTrue(result.opened)
+            self.assertEqual(result.reason, "exact_match")
+            self.assertIsNone(result.telemetry)
+            self.assertEqual(recognizer.calls, [frame])
+            self.assertEqual(relay_calls, ["relay"])
+            self.assertEqual(store.pending_outbox_count(), 1)
 
     def test_denied_no_match_accumulates_completed_ocr_work_without_relay(self):
         trace_clock = SequenceClock(
@@ -438,6 +539,108 @@ class GateProcessorTests(unittest.TestCase):
             "reason": "decision_timeout",
         })
         self.assertEqual(wire["ocr_attempts"][0]["duration_ms"], 60)
+
+    def test_preprocessing_timeout_retains_upstream_terminal_durations(self):
+        captured_at = datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc)
+        wall = [captured_at]
+        monotonic_clock = MutableClock()
+        monotonic_clock.value = 200.0
+
+        def advance(seconds):
+            monotonic_clock.value += seconds
+            wall[0] += timedelta(seconds=seconds)
+
+        advance(0.5)
+        decision_started_at = monotonic_clock.value
+        advance(3.3)
+        original_digest = processor_module._content_digest
+
+        def timed_digest(path):
+            advance(0.8)
+            return original_digest(path)
+
+        recognizer = SequenceRecognizer([PlateObservation("12D3456", 0.99)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "timeout.jpg")
+            with patch(
+                "gate_controller.processor._content_digest", side_effect=timed_digest
+            ):
+                result = self._processor(
+                    LocalStore(Path(directory) / "gate.db"),
+                    RecordingRelay(relay_calls),
+                    recognizer,
+                    clock=lambda: wall[0],
+                    decision_clock=monotonic_clock,
+                    telemetry_clock=monotonic_clock,
+                    telemetry_wall_clock=lambda: wall[0],
+                ).process(
+                    (frame,),
+                    received_at=captured_at,
+                    decision_started_at=decision_started_at,
+                )
+
+        durations = result.telemetry.to_wire()["stage_durations"]
+        self.assertEqual(result.reason, "decision_timeout")
+        self.assertEqual(recognizer.calls, [])
+        self.assertEqual(relay_calls, [])
+        self.assertEqual(durations, {
+            "capture_to_burst_ms": 500,
+            "ocr_ms": 0,
+            "end_to_end_ms": 4_600,
+        })
+
+    def test_preprocessing_stale_path_retains_upstream_terminal_durations(self):
+        captured_at = datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc)
+        wall = [captured_at]
+        monotonic_clock = MutableClock()
+        monotonic_clock.value = 300.0
+
+        def advance(seconds):
+            monotonic_clock.value += seconds
+            wall[0] += timedelta(seconds=seconds)
+
+        advance(0.5)
+        decision_started_at = monotonic_clock.value
+        advance(5.3)
+        original_digest = processor_module._content_digest
+
+        def timed_digest(path):
+            advance(0.4)
+            return original_digest(path)
+
+        recognizer = SequenceRecognizer([PlateObservation("12D3456", 0.99)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "stale-upstream.jpg")
+            with patch(
+                "gate_controller.processor._content_digest", side_effect=timed_digest
+            ):
+                result = self._processor(
+                    LocalStore(Path(directory) / "gate.db"),
+                    RecordingRelay(relay_calls),
+                    recognizer,
+                    clock=lambda: wall[0],
+                    max_image_age=timedelta(seconds=5),
+                    decision_timeout=10.0,
+                    decision_clock=monotonic_clock,
+                    telemetry_clock=monotonic_clock,
+                    telemetry_wall_clock=lambda: wall[0],
+                ).process(
+                    (frame,),
+                    received_at=captured_at,
+                    decision_started_at=decision_started_at,
+                )
+
+        durations = result.telemetry.to_wire()["stage_durations"]
+        self.assertEqual(result.reason, "stale_burst")
+        self.assertEqual(recognizer.calls, [])
+        self.assertEqual(relay_calls, [])
+        self.assertEqual(durations, {
+            "capture_to_burst_ms": 500,
+            "ocr_ms": 0,
+            "end_to_end_ms": 6_200,
+        })
 
     def test_stale_burst_has_zero_ocr_work_and_no_recognizer_or_relay_calls(self):
         wall_now = datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,13 +1,18 @@
+import hashlib
 import tempfile
 import unittest
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import patch
 from PIL import Image
 
+import gate_controller.images as image_tools
+import gate_controller.processor as processor_module
 from gate_controller.models import PlateObservation, RelayResult
 from gate_controller.outbox import EvidenceSpool, OutboxWorker
 from gate_controller.processor import GateProcessor
+from gate_controller.relay import RelayController
 from gate_controller.store import LocalStore
 from gate_controller.authorisation import AuthorisedPlateCache
 from gate_controller.images import rank_images
@@ -58,7 +63,8 @@ class RecordingRelay:
     def __init__(self, calls):
         self.calls = calls
 
-    def trigger(self, source, idempotency_key=None, *, pre_activation_inhibit=None):
+    def trigger(self, source, idempotency_key=None, *, pre_activation_inhibit=None,
+                on_activation=None):
         if pre_activation_inhibit is not None:
             inhibition = pre_activation_inhibit()
             if inhibition is not None:
@@ -68,6 +74,8 @@ class RecordingRelay:
                     idempotency_key=idempotency_key,
                 )
         self.calls.append("relay")
+        if on_activation is not None:
+            on_activation()
         return RelayResult(activated=True, reason="activated", idempotency_key=idempotency_key)
 
 
@@ -96,6 +104,46 @@ class RecordingOutbox:
 class FailingFinalizeStore(LocalStore):
     def finalize_actuation(self, claim, event):
         raise sqlite3.OperationalError("database unavailable after activation")
+
+
+class FailingTelemetryTrace:
+    def __init__(self, failure, **kwargs):
+        self._failure = failure
+        self._trace = ProcessingTrace(**kwargs)
+
+    def _call(self, operation, *args, **kwargs):
+        if self._failure == operation:
+            raise RuntimeError(f"{operation} telemetry failed")
+        return getattr(self._trace, operation)(*args, **kwargs)
+
+    def mark_burst(self):
+        return self._call("mark_burst")
+
+    def add_frame(self, frame):
+        return self._call("add_frame", frame)
+
+    def mark_ocr_start(self):
+        return self._call("mark_ocr_start")
+
+    def add_ocr_attempt(self, attempt):
+        return self._call("add_ocr_attempt", attempt)
+
+    def mark_decision(self, outcome, reason):
+        return self._call("mark_decision", outcome, reason)
+
+    def mark_relay_activation(self):
+        return self._call("mark_relay_activation")
+
+    def set_actuation_outcome(self, claim, attempted, relay_outcome):
+        return self._call("set_actuation_outcome", claim, attempted, relay_outcome)
+
+    def mark_actuation(self, claim, attempted, relay_outcome):
+        if self._failure in {"mark_relay_activation", "set_actuation_outcome"}:
+            raise RuntimeError(f"{self._failure} telemetry failed")
+        return self._trace.mark_actuation(claim, attempted, relay_outcome)
+
+    def finish(self):
+        return self._call("finish")
 
 
 class GateProcessorTests(unittest.TestCase):
@@ -152,7 +200,7 @@ class GateProcessorTests(unittest.TestCase):
         self.assertEqual(wire["ocr_attempts"], [{
             "frame_sequence": 0,
             "duration_ms": 50,
-            "status": "matched",
+            "status": "recognized",
             "plate": "12D3456",
             "confidence": 0.95,
             "make": "Ford",
@@ -231,13 +279,132 @@ class GateProcessorTests(unittest.TestCase):
                 recognizer,
             ).process((frame,))
 
-        attempt = result.telemetry.to_wire()["ocr_attempts"][0]
+        wire = result.telemetry.to_wire()
+        attempt = wire["ocr_attempts"][0]
         self.assertTrue(result.opened)
         self.assertEqual(recognizer.calls, [frame])
         self.assertEqual(relay_calls, ["relay"])
-        self.assertEqual(attempt["status"], "quality_unavailable")
+        self.assertEqual(wire["frames"][0]["status"], "quality_unavailable")
+        self.assertEqual(attempt["status"], "recognized")
         self.assertNotIn(str(frame), str(attempt))
         self.assertNotIn("do not expose", str(attempt))
+
+    def test_decision_to_relay_ends_at_activation_before_pulse_and_finalization(self):
+        trace_clock = MutableClock()
+        trace_clock.value = 10.0
+        calls = []
+
+        class BoundaryBackend:
+            def on(self):
+                calls.append("on")
+                trace_clock.value = 10.08
+
+            def off(self):
+                calls.append("off")
+
+        class AdvancingRecognizer(SequenceRecognizer):
+            def recognise(self, path):
+                result = super().recognise(path)
+                trace_clock.value = 10.05
+                return result
+
+        class AdvancingStore(LocalStore):
+            def finalize_actuation(self, *args, **kwargs):
+                calls.append("finalize")
+                trace_clock.value = 10.88
+                return super().finalize_actuation(*args, **kwargs)
+
+        def pulse(seconds):
+            calls.append(("sleep", seconds))
+            trace_clock.value = 10.58
+
+        recognizer = AdvancingRecognizer([PlateObservation("12D3456", 0.95)])
+        now = datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "activation.jpg")
+            store = AdvancingStore(Path(directory) / "gate.db")
+            relay = RelayController(
+                BoundaryBackend(), pulse_seconds=2, sleeper=pulse, clock=lambda: now
+            )
+            result = self._processor(
+                store,
+                relay,
+                recognizer,
+                clock=lambda: now,
+                telemetry_clock=trace_clock,
+            ).process((frame,))
+
+        durations = result.telemetry.to_wire()["stage_durations"]
+        self.assertTrue(result.opened)
+        self.assertEqual(recognizer.calls, [frame])
+        self.assertEqual(calls, ["off", "on", ("sleep", 2), "off", "finalize"])
+        self.assertEqual(durations["decision_to_relay_ms"], 30)
+        self.assertEqual(durations["end_to_end_ms"], 880)
+
+    def test_trace_factory_failure_does_not_change_successful_processing(self):
+        def fail_factory(**kwargs):
+            raise RuntimeError("trace creation failed")
+
+        self._assert_success_survives_telemetry_failure(trace_factory=fail_factory)
+
+    def test_quality_measurement_failure_does_not_change_successful_processing(self):
+        with patch(
+            "gate_controller.processor.measure_frame_quality",
+            side_effect=RuntimeError("quality failed"),
+        ):
+            self._assert_success_survives_telemetry_failure()
+
+    def test_trace_mark_failures_do_not_change_successful_processing(self):
+        for operation in (
+            "mark_burst",
+            "add_frame",
+            "mark_ocr_start",
+            "add_ocr_attempt",
+            "mark_decision",
+        ):
+            with self.subTest(operation=operation):
+                self._assert_success_survives_telemetry_failure(
+                    trace_factory=lambda operation=operation, **kwargs: FailingTelemetryTrace(
+                        operation, **kwargs
+                    )
+                )
+
+    def test_trace_finish_failure_does_not_suppress_the_processing_result(self):
+        self._assert_success_survives_telemetry_failure(
+            trace_factory=lambda **kwargs: FailingTelemetryTrace("finish", **kwargs)
+        )
+
+    def test_after_relay_telemetry_failure_does_not_change_successful_processing(self):
+        for operation in ("mark_relay_activation", "set_actuation_outcome"):
+            with self.subTest(operation=operation):
+                self._assert_success_survives_telemetry_failure(
+                    trace_factory=lambda operation=operation, **kwargs: FailingTelemetryTrace(
+                        operation, **kwargs
+                    )
+                )
+
+    def _assert_success_survives_telemetry_failure(self, trace_factory=None):
+        recognizer = SequenceRecognizer([PlateObservation("12D3456", 0.95)])
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "frame.jpg")
+            store = LocalStore(Path(directory) / "gate.db")
+            kwargs = {} if trace_factory is None else {"trace_factory": trace_factory}
+            result = self._processor(
+                store,
+                RecordingRelay(relay_calls),
+                recognizer,
+                outbox=object(),
+                **kwargs,
+            ).process((frame,))
+
+            self.assertTrue(result.opened)
+            self.assertEqual(result.reason, "exact_match")
+            self.assertIsNotNone(result.event_id)
+            self.assertIsNone(result.telemetry)
+            self.assertEqual(recognizer.calls, [frame])
+            self.assertEqual(relay_calls, ["relay"])
+            self.assertEqual(store.pending_outbox_count(), 1)
 
     def test_timeout_after_ocr_returns_a_finished_denied_trace_without_relay(self):
         decision_clock = MutableClock()
@@ -323,6 +490,106 @@ class GateProcessorTests(unittest.TestCase):
         self.assertEqual(len(created_traces), 1)
         self.assertEqual(recognizer.calls, [frame])
         self.assertEqual(relay_calls, ["relay"])
+
+    def test_direct_nonduplicate_skips_each_create_one_terminal_trace(self):
+        created_traces = []
+
+        def trace_factory(**kwargs):
+            trace = ProcessingTrace(**kwargs)
+            created_traces.append(trace)
+            return trace
+
+        recognizer = SequenceRecognizer([])
+        relay_calls = []
+        reasons = (
+            "candidate_coalesced",
+            "upload_incomplete",
+            "image_too_large",
+            "queue_coalesced",
+            "stale_startup",
+            "service_stopping",
+            "processing_error",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            processor = self._processor(
+                store,
+                RecordingRelay(relay_calls),
+                recognizer,
+                trace_factory=trace_factory,
+            )
+            results = [
+                processor.record_skipped(
+                    (self._jpeg(directory, f"{index}.jpg", 32 + index),), reason
+                )
+                for index, reason in enumerate(reasons)
+            ]
+
+        self.assertEqual(len(created_traces), len(reasons))
+        self.assertEqual(recognizer.calls, [])
+        self.assertEqual(relay_calls, [])
+        for result, reason in zip(results, reasons):
+            self.assertEqual(result.reason, reason)
+            self.assertEqual(result.telemetry.to_wire()["decision"], {
+                "outcome": "denied",
+                "reason": reason,
+            })
+
+    def test_direct_skip_trace_factory_failure_still_records_the_event(self):
+        def fail_factory(**kwargs):
+            raise RuntimeError("trace creation failed")
+
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            frame = self._jpeg(directory, "skipped.jpg")
+            result = self._processor(
+                store,
+                RecordingRelay([]),
+                SequenceRecognizer([]),
+                outbox=object(),
+                trace_factory=fail_factory,
+            ).record_skipped((frame,), "processing_error")
+
+            self.assertEqual(result.reason, "processing_error")
+            self.assertIsNotNone(result.event_id)
+            self.assertIsNone(result.telemetry)
+            self.assertEqual(store.pending_outbox_count(), 1)
+
+    def test_processing_reuses_unique_frame_digests_for_identity_and_quality(self):
+        recognizer = SequenceRecognizer([
+            PlateObservation(None, 0.0),
+            PlateObservation("NOPE", 0.8),
+        ])
+        with tempfile.TemporaryDirectory() as directory:
+            frames = (
+                self._jpeg(directory, "first.jpg", 32),
+                self._jpeg(directory, "second.jpg", 224),
+            )
+            expected_digests = [
+                hashlib.sha256(frame.read_bytes()).hexdigest() for frame in frames
+            ]
+            store = LocalStore(Path(directory) / "gate.db")
+            with patch(
+                "gate_controller.processor._content_digest",
+                wraps=processor_module._content_digest,
+            ) as processor_digest, patch(
+                "gate_controller.images._content_digest",
+                wraps=image_tools._content_digest,
+            ) as quality_digest:
+                result = self._processor(
+                    store, RecordingRelay([]), recognizer
+                ).process(frames)
+
+            identity_exists = store.event_exists(expected_digests[0])
+
+        self.assertEqual(result.reason, "no_match")
+        self.assertTrue(identity_exists)
+        self.assertEqual(
+            [frame["digest"] for frame in result.telemetry.to_wire()["frames"]],
+            expected_digests,
+        )
+        self.assertEqual(processor_digest.call_count, len(frames))
+        quality_digest.assert_not_called()
 
     def test_activates_relay_before_persisting_or_queuing_optional_work(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -475,6 +475,47 @@ class GateProcessorTests(unittest.TestCase):
             trace_factory=lambda **kwargs: FailingTelemetryTrace("finish", **kwargs)
         )
 
+    def test_telemetry_persistence_failure_does_not_change_terminal_result(self):
+        class FailingTelemetryStore(LocalStore):
+            def attach_event_telemetry(self, event_id, telemetry):
+                raise sqlite3.OperationalError("telemetry disk full")
+
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "frame.jpg")
+            store = FailingTelemetryStore(Path(directory) / "gate.db")
+            relay_calls = []
+
+            result = self._processor(
+                store,
+                RecordingRelay(relay_calls),
+                StaticRecognizer(PlateObservation("12D3456", 0.95)),
+                outbox=object(),
+            ).process((frame,))
+
+            self.assertTrue(result.opened)
+            self.assertEqual(result.reason, "exact_match")
+            self.assertIsNotNone(result.event_id)
+            self.assertIsNotNone(result.telemetry)
+            self.assertEqual(relay_calls, ["relay"])
+            self.assertEqual(store.event_payload(result.event_id)["reason"], "exact_match")
+
+    def test_terminal_result_telemetry_is_attached_to_its_event(self):
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "frame.jpg")
+            store = LocalStore(Path(directory) / "gate.db")
+
+            result = self._processor(
+                store,
+                RecordingRelay([]),
+                StaticRecognizer(PlateObservation("NOPE", 0.95)),
+                outbox=object(),
+            ).process((frame,))
+
+            self.assertEqual(
+                store.event_telemetry(result.event_id)["trace_id"],
+                result.telemetry.trace_id,
+            )
+
     def test_after_relay_telemetry_failure_does_not_change_successful_processing(self):
         for operation in ("mark_relay_activation", "set_actuation_outcome"):
             with self.subTest(operation=operation):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -555,6 +555,35 @@ class GateProcessorTests(unittest.TestCase):
             self.assertIsNone(result.telemetry)
             self.assertEqual(store.pending_outbox_count(), 1)
 
+    def test_duplicate_direct_skip_does_not_create_a_second_trace(self):
+        created_traces = []
+
+        def trace_factory(**kwargs):
+            trace = ProcessingTrace(**kwargs)
+            created_traces.append(trace)
+            return trace
+
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            frame = self._jpeg(directory, "duplicate-skip.jpg")
+            processor = self._processor(
+                store,
+                RecordingRelay([]),
+                SequenceRecognizer([]),
+                outbox=object(),
+                trace_factory=trace_factory,
+            )
+
+            first = processor.record_skipped((frame,), "queue_coalesced")
+            duplicate = processor.record_skipped((frame,), "queue_coalesced")
+
+            self.assertIsNotNone(first.telemetry)
+            self.assertEqual(duplicate.reason, "duplicate_event")
+            self.assertIsNone(duplicate.telemetry)
+            self.assertEqual(duplicate.event_id, first.event_id)
+            self.assertEqual(len(created_traces), 1)
+            self.assertEqual(store.pending_outbox_count(), 1)
+
     def test_processing_reuses_unique_frame_digests_for_identity_and_quality(self):
         recognizer = SequenceRecognizer([
             PlateObservation(None, 0.0),

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -115,6 +115,40 @@ class RelayControllerTests(unittest.TestCase):
             "last_outcome_at": now.isoformat(),
         })
 
+    def test_activation_hook_runs_at_gpio_on_before_the_pulse(self):
+        backend = RecordingBackend()
+        calls = backend.calls
+        controller = RelayController(
+            backend,
+            pulse_seconds=2,
+            sleeper=lambda seconds: calls.append(("sleep", seconds)),
+        )
+
+        result = controller.trigger(
+            "ocr", "upload-1", on_activation=lambda: calls.append("activation")
+        )
+
+        self.assertTrue(result.activated)
+        self.assertEqual(calls, ["off", "on", "activation", ("sleep", 2), "off"])
+
+    def test_activation_hook_failure_does_not_change_the_relay_pulse(self):
+        backend = RecordingBackend()
+        calls = backend.calls
+        controller = RelayController(
+            backend,
+            pulse_seconds=2,
+            sleeper=lambda seconds: calls.append(("sleep", seconds)),
+        )
+
+        result = controller.trigger(
+            "ocr",
+            "upload-1",
+            on_activation=lambda: (_ for _ in ()).throw(RuntimeError("telemetry failed")),
+        )
+
+        self.assertTrue(result.activated)
+        self.assertEqual(calls, ["off", "on", ("sleep", 2), "off"])
+
     def test_initialization_and_shutdown_force_the_output_off(self):
         backend = RecordingBackend()
         controller = RelayController(backend, pulse_seconds=0, sleeper=lambda _: None)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,9 +10,151 @@ from pathlib import Path
 
 from gate_controller.models import GateEvent
 from gate_controller.store import LocalStore
+from gate_controller.telemetry import EventTelemetry, StageDurations
+
+
+def _telemetry(trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2", *, reason="exact_match"):
+    return EventTelemetry(
+        trace_id=trace_id,
+        stage_durations=StageDurations(end_to_end_ms=125),
+        frames=(),
+        ocr_attempts=(),
+        decision_outcome="allowed" if reason == "exact_match" else "denied",
+        decision_reason=reason,
+        actuation_claim="claimed" if reason == "exact_match" else "not_requested",
+        actuation_attempted=reason == "exact_match",
+        relay_outcome="activated" if reason == "exact_match" else "not_attempted",
+        outbox_attempt=0,
+        delivery_state="pending",
+    )
 
 
 class LocalStoreTests(unittest.TestCase):
+    def test_migration_adds_the_bounded_event_telemetry_contract(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+
+            with closing(sqlite3.connect(store.path)) as connection:
+                columns = connection.execute("PRAGMA table_info(event_telemetry)").fetchall()
+                indexes = connection.execute("PRAGMA index_list(event_telemetry)").fetchall()
+
+            self.assertEqual(
+                [(row[1], row[2], row[5]) for row in columns],
+                [
+                    ("event_id", "INTEGER", 1),
+                    ("trace_id", "TEXT", 0),
+                    ("payload", "TEXT", 0),
+                    ("created_at", "TEXT", 0),
+                ],
+            )
+            self.assertTrue(any(row[2] for row in indexes), indexes)
+
+    def test_attach_is_idempotent_and_promotes_only_the_pending_outbox_to_v3(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            event_id = store.record_event_with_outbox(
+                GateEvent(
+                    source="ocr", reason="exact_match", opened=True,
+                    idempotency_key="telemetry-one",
+                    received_at=datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc),
+                ),
+                {"event_id": None, "controller_id": "pi-front-gate"},
+            )
+            telemetry = _telemetry()
+
+            self.assertTrue(store.attach_event_telemetry(event_id, telemetry))
+            self.assertFalse(store.attach_event_telemetry(event_id, telemetry))
+
+            saved = store.event_telemetry(event_id)
+            _, queued = store.pending_outbox_items()[0]
+            self.assertEqual(saved["trace_id"], telemetry.trace_id)
+            self.assertNotIn("schema_version", saved)
+            self.assertEqual(queued["schema_version"], 3)
+            self.assertEqual(queued["telemetry"], saved)
+            self.assertEqual(queued["controller_id"], "pi-front-gate")
+
+    def test_attach_rejects_event_and_trace_identity_conflicts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            first = store.record_event(GateEvent(
+                source="ocr", reason="no_match", opened=False,
+                idempotency_key="telemetry-first", received_at=datetime.now(timezone.utc),
+            ))
+            second = store.record_event(GateEvent(
+                source="ocr", reason="no_match", opened=False,
+                idempotency_key="telemetry-second", received_at=datetime.now(timezone.utc),
+            ))
+            store.attach_event_telemetry(first, _telemetry(reason="no_match"))
+
+            with self.assertRaises(ValueError):
+                store.attach_event_telemetry(
+                    first,
+                    _telemetry("b92dcb71-dd3c-4a82-b522-093f75746295", reason="no_match"),
+                )
+            with self.assertRaises(ValueError):
+                store.attach_event_telemetry(second, _telemetry(reason="no_match"))
+
+    def test_attach_does_not_rewrite_a_completed_v2_outbox_row(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            event_id = store.record_event(GateEvent(
+                source="ocr", reason="no_match", opened=False,
+                idempotency_key="already-sent", received_at=datetime.now(timezone.utc),
+            ))
+            item_id = store.queue_outbox(event_id, {"controller_id": "pi-front-gate"})
+            store.complete_outbox_item(item_id)
+            with closing(sqlite3.connect(store.path)) as connection:
+                before = connection.execute(
+                    "SELECT payload, completed_at FROM outbox WHERE id = ?", (item_id,)
+                ).fetchone()
+
+            self.assertTrue(store.attach_event_telemetry(
+                event_id, _telemetry(reason="no_match")
+            ))
+
+            with closing(sqlite3.connect(store.path)) as connection:
+                after = connection.execute(
+                    "SELECT payload, completed_at FROM outbox WHERE id = ?", (item_id,)
+                ).fetchone()
+            self.assertEqual(after, before)
+            self.assertIsNotNone(store.event_telemetry(event_id))
+
+    def test_retention_removes_only_old_telemetry_with_completed_delivery(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            now = datetime(2026, 8, 16, 12, 0, tzinfo=timezone.utc)
+            event_ids = []
+            for index in range(3):
+                event_id = store.record_event(GateEvent(
+                    source="ocr", reason="no_match", opened=False,
+                    idempotency_key=f"retention-{index}", received_at=now,
+                ))
+                item_id = store.queue_outbox(event_id, {"controller_id": "pi-front-gate"})
+                store.attach_event_telemetry(
+                    event_id,
+                    _telemetry(
+                        f"00000000-0000-4000-8000-00000000000{index}", reason="no_match"
+                    ),
+                )
+                if index != 1:
+                    store.complete_outbox_item(item_id, now)
+                event_ids.append(event_id)
+            with closing(sqlite3.connect(store.path)) as connection, connection:
+                connection.execute(
+                    "UPDATE event_telemetry SET created_at = ? WHERE event_id IN (?, ?)",
+                    (
+                        (now - timedelta(days=31)).isoformat(),
+                        event_ids[0], event_ids[1],
+                    ),
+                )
+
+            removed = store.purge_delivered_telemetry(now - timedelta(days=30))
+
+            self.assertEqual(removed, 1)
+            self.assertIsNone(store.event_telemetry(event_ids[0]))
+            self.assertIsNotNone(store.event_telemetry(event_ids[1]))
+            self.assertIsNotNone(store.event_telemetry(event_ids[2]))
+
     def test_migrates_legacy_truthy_cooldown_values(self):
         for legacy_value in ("True", "Yes", 1):
             with self.subTest(legacy_value=legacy_value), tempfile.TemporaryDirectory() as directory:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from gate_controller.models import GateEvent
 from gate_controller.store import LocalStore
-from gate_controller.telemetry import EventTelemetry, StageDurations
+from gate_controller.telemetry import EventTelemetry, FrameTelemetry, StageDurations
 
 
 def _telemetry(trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2", *, reason="exact_match"):
@@ -30,6 +30,86 @@ def _telemetry(trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2", *, reason="exact
 
 
 class LocalStoreTests(unittest.TestCase):
+    def test_frame_quality_status_survives_persistence_and_outbox_attachment(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            event_id = store.record_event_with_outbox(
+                GateEvent(
+                    source="ocr", reason="no_match", opened=False,
+                    idempotency_key="quality-status",
+                    received_at=datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc),
+                ),
+                {"controller_id": "pi-front-gate"},
+            )
+            telemetry = EventTelemetry(
+                trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+                stage_durations=StageDurations(end_to_end_ms=125),
+                frames=(FrameTelemetry(
+                    sequence=0, digest="a" * 64, width=1, height=1,
+                    sharpness=0, brightness=0, darkness=0,
+                    highlight_clipping=0, status="quality_unavailable",
+                ),),
+                ocr_attempts=(), decision_outcome="denied",
+                decision_reason="no_match", actuation_claim="not_requested",
+                actuation_attempted=False, relay_outcome="not_attempted",
+                outbox_attempt=0, delivery_state="pending",
+            )
+
+            store.attach_event_telemetry(event_id, telemetry)
+            item_id, queued = store.pending_outbox_items()[0]
+            attempted = store.prepare_outbox_attempt(
+                item_id, datetime(2026, 8, 15, 10, 0, 1, tzinfo=timezone.utc)
+            )
+
+            self.assertEqual(
+                store.event_telemetry(event_id)["frames"][0]["status"],
+                "quality_unavailable",
+            )
+            self.assertEqual(
+                queued["telemetry"]["frames"][0]["status"],
+                "quality_unavailable",
+            )
+            self.assertEqual(
+                attempted["telemetry"]["frames"][0]["status"],
+                "quality_unavailable",
+            )
+
+    def test_telemetry_pages_use_received_at_and_event_id_as_a_stable_keyset(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = LocalStore(Path(directory) / "gate.db")
+            received_at = datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc)
+            event_ids = []
+            for index in range(5):
+                event_id = store.record_event(GateEvent(
+                    source="ocr", reason="no_match", opened=False,
+                    idempotency_key=f"page-{index}", received_at=received_at,
+                ))
+                store.attach_event_telemetry(
+                    event_id,
+                    _telemetry(
+                        f"00000000-0000-4000-8000-00000000000{index}",
+                        reason="no_match",
+                    ),
+                )
+                event_ids.append(event_id)
+
+            first = store.event_telemetry_page(received_at, limit=2)
+            second = store.event_telemetry_page(
+                received_at,
+                after=(first[-1]["received_at"], first[-1]["event_id"]),
+                limit=2,
+            )
+            third = store.event_telemetry_page(
+                received_at,
+                after=(second[-1]["received_at"], second[-1]["event_id"]),
+                limit=2,
+            )
+
+            self.assertEqual(
+                [row["event_id"] for row in first + second + third], event_ids
+            )
+            self.assertEqual([len(first), len(second), len(third)], [2, 2, 1])
+
     def test_migration_adds_the_bounded_event_telemetry_contract(self):
         with tempfile.TemporaryDirectory() as directory:
             store = LocalStore(Path(directory) / "gate.db")
@@ -129,7 +209,10 @@ class LocalStoreTests(unittest.TestCase):
                     source="ocr", reason="no_match", opened=False,
                     idempotency_key=f"retention-{index}", received_at=now,
                 ))
-                item_id = store.queue_outbox(event_id, {"controller_id": "pi-front-gate"})
+                item_id = store.queue_outbox(event_id, {
+                    "controller_id": "pi-front-gate",
+                    "image_sha256": f"{index + 1}" * 64,
+                })
                 store.attach_event_telemetry(
                     event_id,
                     _telemetry(
@@ -139,6 +222,13 @@ class LocalStoreTests(unittest.TestCase):
                 if index != 1:
                     store.complete_outbox_item(item_id, now)
                 event_ids.append(event_id)
+            with closing(sqlite3.connect(store.path)) as connection:
+                before = {
+                    event_id: json.loads(payload)
+                    for event_id, payload in connection.execute(
+                        "SELECT event_id, payload FROM outbox"
+                    ).fetchall()
+                }
             with closing(sqlite3.connect(store.path)) as connection, connection:
                 connection.execute(
                     "UPDATE event_telemetry SET created_at = ? WHERE event_id IN (?, ?)",
@@ -154,6 +244,19 @@ class LocalStoreTests(unittest.TestCase):
             self.assertIsNone(store.event_telemetry(event_ids[0]))
             self.assertIsNotNone(store.event_telemetry(event_ids[1]))
             self.assertIsNotNone(store.event_telemetry(event_ids[2]))
+            with closing(sqlite3.connect(store.path)) as connection:
+                after = {
+                    event_id: json.loads(payload)
+                    for event_id, payload in connection.execute(
+                        "SELECT event_id, payload FROM outbox"
+                    ).fetchall()
+                }
+            stripped = dict(before[event_ids[0]])
+            stripped.pop("telemetry")
+            stripped["schema_version"] = 2
+            self.assertEqual(after[event_ids[0]], stripped)
+            self.assertEqual(after[event_ids[1]], before[event_ids[1]])
+            self.assertEqual(after[event_ids[2]], before[event_ids[2]])
 
     def test_migrates_legacy_truthy_cooldown_values(self):
         for legacy_value in ("True", "Yes", 1):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,320 @@
+import re
+import unittest
+from datetime import datetime, timezone
+
+from gate_controller.telemetry import (
+    EventTelemetry,
+    FrameTelemetry,
+    OcrAttemptTelemetry,
+    ProcessingTrace,
+    StageDurations,
+)
+
+
+class TelemetryWireTests(unittest.TestCase):
+    def test_to_wire_clamps_rounds_and_omits_unset_stage_durations(self):
+        telemetry = EventTelemetry(
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            stage_durations=StageDurations(
+                capture_to_burst_ms=-1.1,
+                burst_to_ocr_ms=None,
+                ocr_ms=20.5,
+                decision_ms=900_000,
+            ),
+            frames=(),
+            ocr_attempts=(),
+            decision_outcome="denied",
+            decision_reason="plate_not_authorised",
+            actuation_claim="not_requested",
+            actuation_attempted=False,
+            relay_outcome="not_attempted",
+            outbox_attempt=0,
+            delivery_state="pending",
+        )
+
+        wire = telemetry.to_wire()
+
+        self.assertEqual(wire["stage_durations"], {
+            "capture_to_burst_ms": 0,
+            "ocr_ms": 21,
+            "decision_ms": 600_000,
+        })
+        self.assertEqual(
+            set(wire["stage_durations"]),
+            {"capture_to_burst_ms", "ocr_ms", "decision_ms"},
+        )
+
+    def test_to_wire_emits_the_exact_v3_consumer_vocabulary(self):
+        telemetry = EventTelemetry(
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            stage_durations=StageDurations(
+                capture_to_burst_ms=1,
+                burst_to_ocr_ms=2,
+                ocr_ms=3,
+                decision_ms=4,
+                decision_to_relay_ms=5,
+                end_to_end_ms=6,
+                delivery_lag_ms=7,
+            ),
+            frames=(
+                FrameTelemetry(
+                    sequence=0,
+                    digest="a" * 64,
+                    width=1920,
+                    height=1080,
+                    sharpness=0.8,
+                    brightness=0.4,
+                    darkness=0.2,
+                    highlight_clipping=0.1,
+                ),
+            ),
+            ocr_attempts=(
+                OcrAttemptTelemetry(
+                    frame_sequence=0,
+                    duration_ms=31,
+                    status="matched",
+                    plate="131D2696",
+                    confidence=0.88,
+                    make="Ford",
+                    colour="Blue",
+                ),
+            ),
+            decision_outcome="denied",
+            decision_reason="plate_not_authorised",
+            actuation_claim="not_requested",
+            actuation_attempted=False,
+            relay_outcome="not_attempted",
+            outbox_attempt=1,
+            delivery_state="delivered",
+        )
+
+        wire = telemetry.to_wire()
+
+        self.assertEqual(wire, {
+            "schema_version": 3,
+            "trace_id": "ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            "taxonomy_version": 1,
+            "stage_durations": {
+                "capture_to_burst_ms": 1,
+                "burst_to_ocr_ms": 2,
+                "ocr_ms": 3,
+                "decision_ms": 4,
+                "decision_to_relay_ms": 5,
+                "end_to_end_ms": 6,
+                "delivery_lag_ms": 7,
+            },
+            "frames": [{
+                "sequence": 0,
+                "digest": "a" * 64,
+                "width": 1920,
+                "height": 1080,
+                "sharpness": 0.8,
+                "brightness": 0.4,
+                "darkness": 0.2,
+                "highlight_clipping": 0.1,
+            }],
+            "ocr_attempts": [{
+                "frame_sequence": 0,
+                "duration_ms": 31,
+                "status": "matched",
+                "plate": "131D2696",
+                "confidence": 0.88,
+                "make": "Ford",
+                "colour": "Blue",
+            }],
+            "decision": {"outcome": "denied", "reason": "plate_not_authorised"},
+            "actuation": {
+                "claim": "not_requested",
+                "attempted": False,
+                "relay_outcome": "not_attempted",
+            },
+            "delivery": {"outbox_attempt": 1, "state": "delivered"},
+        })
+
+    def test_to_wire_caps_collections_and_normalizes_all_consumer_bounds(self):
+        frames = tuple(
+            FrameTelemetry(
+                sequence=index + 10,
+                digest=("%x" % index) * 64,
+                width=20_000,
+                height=-10,
+                sharpness=2,
+                brightness=-1,
+                darkness=0.25,
+                highlight_clipping=3,
+            )
+            for index in range(9)
+        )
+        attempts = tuple(
+            OcrAttemptTelemetry(
+                frame_sequence=index + 10,
+                duration_ms=700_000.2,
+                status="x" * 129,
+                plate="P" * 129,
+                confidence=2,
+                make="M" * 129,
+                colour="",
+            )
+            for index in range(9)
+        )
+        telemetry = EventTelemetry(
+            trace_id="not-a-uuid",
+            stage_durations=StageDurations(),
+            frames=frames,
+            ocr_attempts=attempts,
+            decision_outcome="bad/status",
+            decision_reason="",
+            actuation_claim="C" * 129,
+            actuation_attempted=True,
+            relay_outcome="bad/status",
+            outbox_attempt=2_000,
+            delivery_state="",
+        )
+
+        wire = telemetry.to_wire()
+
+        self.assertRegex(wire["trace_id"], re.compile(
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+            re.IGNORECASE,
+        ))
+        self.assertEqual(len(wire["frames"]), 8)
+        self.assertEqual(len(wire["ocr_attempts"]), 8)
+        self.assertEqual(wire["frames"][0], {
+            "sequence": 7,
+            "digest": "0" * 64,
+            "width": 16_384,
+            "height": 1,
+            "sharpness": 1.0,
+            "brightness": 0.0,
+            "darkness": 0.25,
+            "highlight_clipping": 1.0,
+        })
+        self.assertEqual(wire["ocr_attempts"][0], {
+            "frame_sequence": 7,
+            "duration_ms": 600_000,
+            "status": "unknown",
+            "plate": "P" * 128,
+            "confidence": 1.0,
+            "make": "M" * 128,
+            "colour": None,
+        })
+        self.assertEqual(wire["decision"], {"outcome": "unknown", "reason": "unknown"})
+        self.assertEqual(wire["actuation"], {
+            "claim": "unknown",
+            "attempted": True,
+            "relay_outcome": "unknown",
+        })
+        self.assertEqual(wire["delivery"], {"outbox_attempt": 1_000, "state": "unknown"})
+
+    def test_to_wire_has_no_path_or_raw_response_fields_and_is_deterministic(self):
+        telemetry = EventTelemetry(
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            stage_durations=StageDurations(),
+            frames=(
+                FrameTelemetry(0, "a" * 64, 1, 1, 0, 0, 0, 0),
+            ),
+            ocr_attempts=(
+                OcrAttemptTelemetry(0, 0, "no_plate"),
+            ),
+            decision_outcome="denied",
+            decision_reason="plate_not_authorised",
+            actuation_claim="not_requested",
+            actuation_attempted=False,
+            relay_outcome="not_attempted",
+            outbox_attempt=0,
+            delivery_state="pending",
+        )
+
+        first = telemetry.to_wire()
+        second = telemetry.to_wire()
+
+        self.assertEqual(first, second)
+        self.assertFalse({"path", "raw_response", "response", "exception"} & set(first))
+        self.assertFalse({"path", "raw_response", "response", "exception"} & set(first["frames"][0]))
+        self.assertFalse({"path", "raw_response", "response", "exception"} & set(first["ocr_attempts"][0]))
+
+    def test_to_wire_keeps_a_stable_snapshot_for_invalid_ids_and_generators(self):
+        telemetry = EventTelemetry(
+            trace_id="invalid",
+            stage_durations=StageDurations(),
+            frames=(
+                frame
+                for frame in (FrameTelemetry(0, "a" * 64, 1, 1, 0, 0, 0, 0),)
+            ),
+            ocr_attempts=(
+                attempt
+                for attempt in (OcrAttemptTelemetry(0, 0, "no_plate"),)
+            ),
+            decision_outcome="denied",
+            decision_reason="plate_not_authorised",
+            actuation_claim="not_requested",
+            actuation_attempted=False,
+            relay_outcome="not_attempted",
+            outbox_attempt=0,
+            delivery_state="pending",
+        )
+
+        self.assertEqual(telemetry.to_wire(), telemetry.to_wire())
+
+
+class ProcessingTraceTests(unittest.TestCase):
+    def test_first_marks_win_and_finish_builds_bounded_telemetry(self):
+        monotonic = iter((10.0, 10.125, 10.2, 10.35, 10.4, 10.6, 10.9))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: datetime(2026, 8, 15, tzinfo=timezone.utc),
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+        )
+
+        trace.mark_burst()
+        trace.mark_burst()
+        trace.add_frame(FrameTelemetry(0, "a" * 64, 1920, 1080, 0.8, 0.4, 0.2, 0.1))
+        trace.add_ocr_attempt(OcrAttemptTelemetry(0, 75, "matched", "131D2696", 0.88, "Ford", "Blue"))
+        trace.mark_decision("allowed", "plate_authorised")
+        trace.mark_decision("denied", "ignored")
+        trace.mark_actuation("claimed", True, "activated")
+        telemetry = trace.finish(outbox_attempt=1, delivery_state="pending")
+
+        self.assertEqual(telemetry.to_wire(), {
+            "schema_version": 3,
+            "trace_id": "ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            "taxonomy_version": 1,
+            "stage_durations": {
+                "capture_to_burst_ms": 125,
+                "burst_to_ocr_ms": 75,
+                "ocr_ms": 75,
+                "decision_ms": 150,
+                "decision_to_relay_ms": 50,
+                "end_to_end_ms": 600,
+            },
+            "frames": [{
+                "sequence": 0,
+                "digest": "a" * 64,
+                "width": 1920,
+                "height": 1080,
+                "sharpness": 0.8,
+                "brightness": 0.4,
+                "darkness": 0.2,
+                "highlight_clipping": 0.1,
+            }],
+            "ocr_attempts": [{
+                "frame_sequence": 0,
+                "duration_ms": 75,
+                "status": "matched",
+                "plate": "131D2696",
+                "confidence": 0.88,
+                "make": "Ford",
+                "colour": "Blue",
+            }],
+            "decision": {"outcome": "allowed", "reason": "plate_authorised"},
+            "actuation": {
+                "claim": "claimed",
+                "attempted": True,
+                "relay_outcome": "activated",
+            },
+            "delivery": {"outbox_attempt": 1, "state": "pending"},
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -256,10 +256,37 @@ class TelemetryWireTests(unittest.TestCase):
 
         self.assertEqual(telemetry.to_wire(), telemetry.to_wire())
 
+    def test_to_wire_caps_frame_candidates_before_discarding_invalid_frames(self):
+        frames = [
+            FrameTelemetry(0, "not-a-digest", 1, 1, 0, 0, 0, 0),
+            *(
+                FrameTelemetry(index, f"{index:x}" * 64, 1, 1, 0, 0, 0, 0)
+                for index in range(1, 9)
+            ),
+        ]
+        telemetry = EventTelemetry(
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            stage_durations=StageDurations(),
+            frames=frames,
+            ocr_attempts=(),
+            decision_outcome="denied",
+            decision_reason="plate_not_authorised",
+            actuation_claim="not_requested",
+            actuation_attempted=False,
+            relay_outcome="not_attempted",
+            outbox_attempt=0,
+            delivery_state="pending",
+        )
+
+        self.assertEqual(
+            [frame["sequence"] for frame in telemetry.to_wire()["frames"]],
+            [1, 2, 3, 4, 5, 6, 7],
+        )
+
 
 class ProcessingTraceTests(unittest.TestCase):
-    def test_first_marks_win_and_finish_builds_bounded_telemetry(self):
-        monotonic = iter((10.0, 10.125, 10.2, 10.35, 10.4, 10.6, 10.9))
+    def test_ocr_start_and_end_boundaries_do_not_double_count_work(self):
+        monotonic = iter((10.0, 10.1, 10.15, 10.4, 10.45, 10.65, 10.7, 10.8, 11.0))
         trace = ProcessingTrace(
             monotonic_clock=lambda: next(monotonic),
             wall_clock=lambda: datetime(2026, 8, 15, tzinfo=timezone.utc),
@@ -268,51 +295,113 @@ class ProcessingTraceTests(unittest.TestCase):
 
         trace.mark_burst()
         trace.mark_burst()
-        trace.add_frame(FrameTelemetry(0, "a" * 64, 1920, 1080, 0.8, 0.4, 0.2, 0.1))
-        trace.add_ocr_attempt(OcrAttemptTelemetry(0, 75, "matched", "131D2696", 0.88, "Ford", "Blue"))
+        mark_ocr_start = getattr(trace, "mark_ocr_start", None)
+        self.assertIsNotNone(mark_ocr_start)
+        mark_ocr_start()
+        try:
+            no_plate = OcrAttemptTelemetry(frame_sequence=0, status="no_plate")
+        except TypeError as error:
+            self.fail(f"trace-timed OCR attempts still require a duration: {error}")
+        trace.add_ocr_attempt(no_plate)
+        mark_ocr_start()
+        trace.add_ocr_attempt(
+            OcrAttemptTelemetry(
+                frame_sequence=1,
+                status="matched",
+                plate="131D2696",
+                confidence=0.88,
+                make="Ford",
+                colour="Blue",
+            )
+        )
         trace.mark_decision("allowed", "plate_authorised")
         trace.mark_decision("denied", "ignored")
         trace.mark_actuation("claimed", True, "activated")
         telemetry = trace.finish(outbox_attempt=1, delivery_state="pending")
 
-        self.assertEqual(telemetry.to_wire(), {
-            "schema_version": 3,
-            "trace_id": "ae2398aa-7107-44f4-a723-290de0f8c7b2",
-            "taxonomy_version": 1,
-            "stage_durations": {
-                "capture_to_burst_ms": 125,
-                "burst_to_ocr_ms": 75,
-                "ocr_ms": 75,
-                "decision_ms": 150,
-                "decision_to_relay_ms": 50,
-                "end_to_end_ms": 600,
-            },
-            "frames": [{
-                "sequence": 0,
-                "digest": "a" * 64,
-                "width": 1920,
-                "height": 1080,
-                "sharpness": 0.8,
-                "brightness": 0.4,
-                "darkness": 0.2,
-                "highlight_clipping": 0.1,
-            }],
-            "ocr_attempts": [{
+        wire = telemetry.to_wire()
+        self.assertEqual(wire["stage_durations"], {
+            "capture_to_burst_ms": 100,
+            "burst_to_ocr_ms": 50,
+            "ocr_ms": 450,
+            "decision_ms": 50,
+            "decision_to_relay_ms": 100,
+            "end_to_end_ms": 1_000,
+        })
+        self.assertEqual(wire["ocr_attempts"], [
+            {
                 "frame_sequence": 0,
-                "duration_ms": 75,
+                "duration_ms": 250,
+                "status": "no_plate",
+                "plate": None,
+                "confidence": None,
+                "make": None,
+                "colour": None,
+            },
+            {
+                "frame_sequence": 1,
+                "duration_ms": 200,
                 "status": "matched",
                 "plate": "131D2696",
                 "confidence": 0.88,
                 "make": "Ford",
                 "colour": "Blue",
-            }],
-            "decision": {"outcome": "allowed", "reason": "plate_authorised"},
-            "actuation": {
-                "claim": "claimed",
-                "attempted": True,
-                "relay_outcome": "activated",
             },
-            "delivery": {"outbox_attempt": 1, "state": "pending"},
+        ])
+
+    def test_add_ocr_attempt_requires_an_explicit_start_mark(self):
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: 10.0,
+            wall_clock=lambda: datetime(2026, 8, 15, tzinfo=timezone.utc),
+        )
+
+        with self.assertRaises(RuntimeError):
+            trace.add_ocr_attempt(OcrAttemptTelemetry(0, 0, "no_plate"))
+
+    def test_duplicate_actuation_and_finish_keep_the_first_terminal_snapshot(self):
+        monotonic = iter((10.0, 10.1, 10.2, 10.3, 10.4))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: datetime(2026, 8, 15, tzinfo=timezone.utc),
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+        )
+
+        trace.mark_burst()
+        trace.mark_decision("allowed", "plate_authorised")
+        trace.mark_actuation("claimed", True, "activated")
+        trace.mark_actuation("ignored", False, "ignored")
+        first = trace.finish(outbox_attempt=0, delivery_state="pending")
+        second = trace.finish(outbox_attempt=2, delivery_state="delivered")
+
+        self.assertIs(first, second)
+        self.assertEqual(first.to_wire()["actuation"], {
+            "claim": "claimed",
+            "attempted": True,
+            "relay_outcome": "activated",
+        })
+        self.assertEqual(
+            first.to_wire()["delivery"],
+            {"outbox_attempt": 0, "state": "pending"},
+        )
+        self.assertEqual(first.to_wire()["stage_durations"]["end_to_end_ms"], 400)
+
+    def test_zero_ocr_terminal_result_reports_zero_work_and_omits_ocr_boundaries(self):
+        monotonic = iter((10.0, 10.1, 10.2, 10.4))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: datetime(2026, 8, 15, tzinfo=timezone.utc),
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+        )
+
+        trace.mark_burst()
+        trace.mark_decision("denied", "capture_failed")
+        telemetry = trace.finish()
+
+        self.assertEqual(telemetry.to_wire()["ocr_attempts"], [])
+        self.assertEqual(telemetry.to_wire()["stage_durations"], {
+            "capture_to_burst_ms": 100,
+            "ocr_ms": 0,
+            "end_to_end_ms": 400,
         })
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -112,6 +112,7 @@ class TelemetryWireTests(unittest.TestCase):
                 "brightness": 0.4,
                 "darkness": 0.2,
                 "highlight_clipping": 0.1,
+                "status": "ok",
             }],
             "ocr_attempts": [{
                 "frame_sequence": 0,
@@ -142,6 +143,7 @@ class TelemetryWireTests(unittest.TestCase):
                 brightness=-1,
                 darkness=0.25,
                 highlight_clipping=3,
+                status="bad/status",
             )
             for index in range(9)
         )
@@ -188,6 +190,7 @@ class TelemetryWireTests(unittest.TestCase):
             "brightness": 0.0,
             "darkness": 0.25,
             "highlight_clipping": 1.0,
+            "status": "unknown",
         })
         self.assertEqual(wire["ocr_attempts"][0], {
             "frame_sequence": 7,
@@ -357,6 +360,32 @@ class ProcessingTraceTests(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             trace.add_ocr_attempt(OcrAttemptTelemetry(0, 0, "no_plate"))
+
+    def test_relay_duration_ends_at_activation_before_outcome_finalization(self):
+        monotonic = iter((10.0, 10.1, 10.2, 10.25, 10.9))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: datetime(2026, 8, 15, tzinfo=timezone.utc),
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+        )
+
+        trace.mark_burst()
+        trace.mark_decision("allowed", "plate_authorised")
+        trace.mark_relay_activation()
+        trace.set_actuation_outcome("claimed", True, "activated")
+        telemetry = trace.finish()
+
+        self.assertEqual(telemetry.to_wire()["stage_durations"], {
+            "capture_to_burst_ms": 100,
+            "ocr_ms": 0,
+            "decision_to_relay_ms": 50,
+            "end_to_end_ms": 900,
+        })
+        self.assertEqual(telemetry.to_wire()["actuation"], {
+            "claim": "claimed",
+            "attempted": True,
+            "relay_outcome": "activated",
+        })
 
     def test_duplicate_actuation_and_finish_keep_the_first_terminal_snapshot(self):
         monotonic = iter((10.0, 10.1, 10.2, 10.3, 10.4))

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,6 +1,6 @@
 import re
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from gate_controller.telemetry import (
     EventTelemetry,
@@ -288,6 +288,85 @@ class TelemetryWireTests(unittest.TestCase):
 
 
 class ProcessingTraceTests(unittest.TestCase):
+    def test_upstream_boundaries_anchor_wall_capture_to_monotonic_burst(self):
+        captured_at = datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc)
+        monotonic = iter((101.0, 101.1, 101.2))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: captured_at + timedelta(seconds=1),
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+        )
+
+        trace.seed_upstream(captured_at, 100.5)
+        trace.mark_ocr_start()
+        telemetry = trace.finish()
+
+        self.assertEqual(telemetry.to_wire()["stage_durations"], {
+            "capture_to_burst_ms": 500,
+            "burst_to_ocr_ms": 600,
+            "ocr_ms": 0,
+            "end_to_end_ms": 1_200,
+        })
+
+    def test_upstream_capture_clamps_only_small_cross_clock_skew(self):
+        wall_anchor = datetime(2026, 8, 15, 10, 0, 1, tzinfo=timezone.utc)
+        monotonic = iter((101.0, 101.1, 101.2))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: wall_anchor,
+        )
+
+        trace.seed_upstream(
+            wall_anchor - timedelta(seconds=0.51),
+            100.48,
+        )
+        trace.mark_ocr_start()
+        telemetry = trace.finish()
+
+        self.assertEqual(telemetry.to_wire()["stage_durations"], {
+            "capture_to_burst_ms": 0,
+            "burst_to_ocr_ms": 620,
+            "ocr_ms": 0,
+            "end_to_end_ms": 720,
+        })
+
+    def test_inconsistent_upstream_capture_is_unavailable_not_fabricated(self):
+        wall_anchor = datetime(2026, 8, 15, 10, 0, 1, tzinfo=timezone.utc)
+        monotonic = iter((101.0, 101.1, 101.2))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: wall_anchor,
+        )
+
+        trace.seed_upstream(
+            wall_anchor - timedelta(seconds=0.8),
+            100.0,
+        )
+        trace.mark_ocr_start()
+        telemetry = trace.finish()
+
+        durations = telemetry.to_wire()["stage_durations"]
+        self.assertNotIn("capture_to_burst_ms", durations)
+        self.assertNotIn("end_to_end_ms", durations)
+        self.assertEqual(durations, {
+            "burst_to_ocr_ms": 1_100,
+            "ocr_ms": 0,
+        })
+
+    def test_invalid_upstream_timestamps_leave_all_derived_stages_unavailable(self):
+        monotonic = iter((101.0, 101.1, 101.2))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(monotonic),
+            wall_clock=lambda: datetime(2026, 8, 15, 10, 0, 1, tzinfo=timezone.utc),
+        )
+
+        trace.seed_upstream(datetime(2026, 8, 15, 10, 0), float("nan"))
+        trace.mark_ocr_start()
+        telemetry = trace.finish()
+
+        durations = telemetry.to_wire()["stage_durations"]
+        self.assertEqual(durations, {"ocr_ms": 0})
+
     def test_ocr_start_and_end_boundaries_do_not_double_count_work(self):
         monotonic = iter((10.0, 10.1, 10.15, 10.4, 10.45, 10.65, 10.7, 10.8, 11.0))
         trace = ProcessingTrace(

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -244,15 +244,11 @@ class TelemetryExportTests(unittest.TestCase):
             store, _ = self._store_with_telemetry(root)
             blocker = sqlite3.connect(store.path)
             blocker.execute("BEGIN EXCLUSIVE")
-
-            def short_live_connection():
-                return sqlite3.connect(store.path, timeout=0.05)
-
+            budget_seconds = 0.250
+            scheduler_tolerance_seconds = 0.030
             started = time.monotonic()
             try:
-                with mock.patch.object(
-                    store, "_connect", side_effect=short_live_connection
-                ), self.assertRaisesRegex(TimeoutError, "snapshot"):
+                with self.assertRaisesRegex(TimeoutError, "snapshot"):
                     export_telemetry(
                         store, format="json",
                         since=datetime(2026, 8, 1, tzinfo=timezone.utc),
@@ -262,7 +258,12 @@ class TelemetryExportTests(unittest.TestCase):
                 blocker.rollback()
                 blocker.close()
 
-            self.assertLess(time.monotonic() - started, 1.0)
+            elapsed = time.monotonic() - started
+            self.assertLessEqual(
+                elapsed,
+                budget_seconds + scheduler_tolerance_seconds,
+                f"snapshot contention took {elapsed:.3f}s",
+            )
 
     def test_export_requires_an_explicit_output_and_supported_format(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -1,0 +1,140 @@
+import csv
+import json
+import os
+import sqlite3
+import stat
+import tempfile
+import unittest
+from contextlib import closing
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+from gate_controller.models import GateEvent
+from gate_controller.store import LocalStore
+from gate_controller.telemetry import EventTelemetry, StageDurations
+from gate_controller.telemetry_export import export_telemetry
+
+
+class TelemetryExportTests(unittest.TestCase):
+    def _store_with_telemetry(self, root: Path):
+        store = LocalStore(root / "gate.db")
+        event_id = store.record_event(GateEvent(
+            source="ocr", reason="no_match", opened=False,
+            idempotency_key="export-one",
+            received_at=datetime(2026, 8, 15, 10, 0, tzinfo=timezone.utc),
+        ))
+        store.attach_event_telemetry(event_id, EventTelemetry(
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            stage_durations=StageDurations(end_to_end_ms=125),
+            frames=(), ocr_attempts=(),
+            decision_outcome="denied", decision_reason="no_match",
+            actuation_claim="not_requested", actuation_attempted=False,
+            relay_outcome="not_attempted", outbox_attempt=0,
+            delivery_state="pending",
+        ))
+        return store, event_id
+
+    def test_json_export_is_bounded_by_since_and_redacts_unsafe_stored_fields(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store, event_id = self._store_with_telemetry(root)
+            with closing(sqlite3.connect(store.path)) as connection, connection:
+                payload = store.event_telemetry(event_id)
+                payload.update({
+                    "api_token": "do-not-export",
+                    "image_path": "/private/camera.jpg",
+                    "image": {"data_base64": "do-not-export"},
+                })
+                connection.execute(
+                    "UPDATE event_telemetry SET payload = ? WHERE event_id = ?",
+                    (json.dumps(payload), event_id),
+                )
+            output = root / "telemetry.json"
+
+            count = export_telemetry(
+                store,
+                format="json",
+                since=datetime(2026, 8, 1, tzinfo=timezone.utc),
+                output=output,
+            )
+
+            exported = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(count, 1)
+            self.assertEqual(exported[0]["event_id"], event_id)
+            self.assertEqual(exported[0]["telemetry"]["trace_id"], payload["trace_id"])
+            encoded = json.dumps(exported)
+            for forbidden in ("do-not-export", "image_path", "data_base64", "api_token"):
+                self.assertNotIn(forbidden, encoded)
+            self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o600)
+
+            later = root / "later.json"
+            self.assertEqual(export_telemetry(
+                store,
+                format="json",
+                since=datetime.now(timezone.utc) + timedelta(days=1),
+                output=later,
+            ), 0)
+            self.assertEqual(json.loads(later.read_text(encoding="utf-8")), [])
+
+    def test_csv_export_flattens_only_the_safe_diagnostic_contract(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store, event_id = self._store_with_telemetry(root)
+            output = root / "telemetry.csv"
+
+            self.assertEqual(export_telemetry(
+                store, format="csv",
+                since=datetime(2026, 8, 1, tzinfo=timezone.utc), output=output,
+            ), 1)
+
+            with output.open(newline="", encoding="utf-8") as source:
+                rows = list(csv.DictReader(source))
+            self.assertEqual(rows[0]["event_id"], str(event_id))
+            self.assertEqual(rows[0]["trace_id"], "ae2398aa-7107-44f4-a723-290de0f8c7b2")
+            self.assertEqual(rows[0]["end_to_end_ms"], "125")
+            headings = set(rows[0])
+            self.assertFalse(any(
+                forbidden in heading
+                for heading in headings
+                for forbidden in ("image", "path", "token", "secret", "credential")
+            ))
+
+    def test_atomic_failure_preserves_existing_output_and_removes_temporary_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store, _ = self._store_with_telemetry(root)
+            output = root / "telemetry.json"
+            output.write_text("previous", encoding="utf-8")
+
+            with mock.patch(
+                "gate_controller.telemetry_export.os.replace",
+                side_effect=OSError("replace failed"),
+            ), self.assertRaises(OSError):
+                export_telemetry(
+                    store, format="json",
+                    since=datetime(2026, 8, 1, tzinfo=timezone.utc), output=output,
+                )
+
+            self.assertEqual(output.read_text(encoding="utf-8"), "previous")
+            self.assertEqual(list(root.glob(".telemetry-*.tmp")), [])
+
+    def test_export_requires_an_explicit_output_and_supported_format(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store, _ = self._store_with_telemetry(Path(directory))
+
+            with self.assertRaises(ValueError):
+                export_telemetry(
+                    store, format="json",
+                    since=datetime(2026, 8, 1, tzinfo=timezone.utc), output=None,
+                )
+            with self.assertRaises(ValueError):
+                export_telemetry(
+                    store, format="xml",
+                    since=datetime(2026, 8, 1, tzinfo=timezone.utc),
+                    output=Path(directory) / "telemetry.xml",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -4,6 +4,8 @@ import os
 import sqlite3
 import stat
 import tempfile
+import threading
+import time
 import unittest
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
@@ -12,7 +14,8 @@ from unittest import mock
 
 from gate_controller.models import GateEvent
 from gate_controller.store import LocalStore
-from gate_controller.telemetry import EventTelemetry, StageDurations
+import gate_controller.telemetry_export as telemetry_export_module
+from gate_controller.telemetry import EventTelemetry, FrameTelemetry, StageDurations
 from gate_controller.telemetry_export import export_telemetry
 
 
@@ -27,7 +30,11 @@ class TelemetryExportTests(unittest.TestCase):
         store.attach_event_telemetry(event_id, EventTelemetry(
             trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
             stage_durations=StageDurations(end_to_end_ms=125),
-            frames=(), ocr_attempts=(),
+            frames=(FrameTelemetry(
+                sequence=0, digest="a" * 64, width=1, height=1,
+                sharpness=0, brightness=0, darkness=0,
+                highlight_clipping=0, status="quality_unavailable",
+            ),), ocr_attempts=(),
             decision_outcome="denied", decision_reason="no_match",
             actuation_claim="not_requested", actuation_attempted=False,
             relay_outcome="not_attempted", outbox_attempt=0,
@@ -63,6 +70,10 @@ class TelemetryExportTests(unittest.TestCase):
             self.assertEqual(count, 1)
             self.assertEqual(exported[0]["event_id"], event_id)
             self.assertEqual(exported[0]["telemetry"]["trace_id"], payload["trace_id"])
+            self.assertEqual(
+                exported[0]["telemetry"]["frames"][0]["status"],
+                "quality_unavailable",
+            )
             encoded = json.dumps(exported)
             for forbidden in ("do-not-export", "image_path", "data_base64", "api_token"):
                 self.assertNotIn(forbidden, encoded)
@@ -118,6 +129,140 @@ class TelemetryExportTests(unittest.TestCase):
 
             self.assertEqual(output.read_text(encoding="utf-8"), "previous")
             self.assertEqual(list(root.glob(".telemetry-*.tmp")), [])
+
+    def test_export_rejects_database_sidecars_and_same_file_aliases(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store, event_id = self._store_with_telemetry(root)
+            symlink = root / "database-symlink"
+            symlink.symlink_to(store.path)
+            hardlink = root / "database-hardlink"
+            os.link(store.path, hardlink)
+            alias_directory = root / "database-parent-alias"
+            alias_directory.symlink_to(root, target_is_directory=True)
+            outputs = (
+                store.path,
+                Path(f"{store.path}-wal"),
+                Path(f"{store.path}-shm"),
+                Path(f"{store.path}-journal"),
+                symlink,
+                hardlink,
+                alias_directory / store.path.name,
+            )
+
+            for output in outputs:
+                with self.subTest(output=output), mock.patch(
+                    "gate_controller.telemetry_export.os.replace",
+                    side_effect=AssertionError("unsafe database replacement reached"),
+                ), self.assertRaisesRegex(ValueError, "database"):
+                    export_telemetry(
+                        store, format="json",
+                        since=datetime(2026, 8, 1, tzinfo=timezone.utc),
+                        output=output,
+                    )
+
+            self.assertIsNotNone(store.event_telemetry(event_id))
+
+    def test_output_is_rechecked_for_database_aliases_before_replace(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store, _ = self._store_with_telemetry(root)
+            output = root / "telemetry.json"
+            original_write = telemetry_export_module._write
+
+            def retarget_output(destination, format, rows):
+                result = original_write(destination, format, rows)
+                output.symlink_to(store.path)
+                return result
+
+            with mock.patch.object(
+                telemetry_export_module, "_write", side_effect=retarget_output
+            ), mock.patch(
+                "gate_controller.telemetry_export.os.replace",
+                side_effect=AssertionError("unsafe database replacement reached"),
+            ), self.assertRaisesRegex(ValueError, "database"):
+                export_telemetry(
+                    store, format="json",
+                    since=datetime(2026, 8, 1, tzinfo=timezone.utc), output=output,
+                )
+
+    def test_concurrent_snapshot_export_does_not_delay_an_actuation_claim(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store, _ = self._store_with_telemetry(root)
+            output = root / "telemetry.json"
+            export_paused = threading.Event()
+            release_export = threading.Event()
+            errors = []
+            original_safe_row = telemetry_export_module._safe_row
+
+            def pause_snapshot_row(row):
+                export_paused.set()
+                release_export.wait(timeout=2)
+                return original_safe_row(row)
+
+            def run_export():
+                try:
+                    export_telemetry(
+                        store, format="json",
+                        since=datetime(2026, 8, 1, tzinfo=timezone.utc), output=output,
+                    )
+                except Exception as error:
+                    errors.append(error)
+
+            with mock.patch.object(
+                store, "event_telemetry_rows",
+                side_effect=AssertionError("export read the live database"),
+            ), mock.patch.object(
+                store, "event_telemetry_page",
+                side_effect=AssertionError("export paged the live database"),
+            ), mock.patch.object(
+                telemetry_export_module, "_safe_row", side_effect=pause_snapshot_row
+            ):
+                export_thread = threading.Thread(target=run_export)
+                export_thread.start()
+                self.assertTrue(export_paused.wait(timeout=1))
+                release_timer = threading.Timer(0.5, release_export.set)
+                release_timer.start()
+                started = time.monotonic()
+                claim = LocalStore(store.path).claim_actuation(
+                    "claim-during-export", datetime.now(timezone.utc)
+                )
+                elapsed = time.monotonic() - started
+                release_export.set()
+                release_timer.cancel()
+                export_thread.join(timeout=2)
+
+            self.assertEqual(errors, [])
+            self.assertFalse(export_thread.is_alive())
+            self.assertEqual(claim.status, "claimed")
+            self.assertLess(elapsed, 0.25)
+
+    def test_snapshot_busy_wait_is_bounded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store, _ = self._store_with_telemetry(root)
+            blocker = sqlite3.connect(store.path)
+            blocker.execute("BEGIN EXCLUSIVE")
+
+            def short_live_connection():
+                return sqlite3.connect(store.path, timeout=0.05)
+
+            started = time.monotonic()
+            try:
+                with mock.patch.object(
+                    store, "_connect", side_effect=short_live_connection
+                ), self.assertRaisesRegex(TimeoutError, "snapshot"):
+                    export_telemetry(
+                        store, format="json",
+                        since=datetime(2026, 8, 1, tzinfo=timezone.utc),
+                        output=root / "telemetry.json",
+                    )
+            finally:
+                blocker.rollback()
+                blocker.close()
+
+            self.assertLess(time.monotonic() - started, 1.0)
 
     def test_export_requires_an_explicit_output_and_supported_format(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## What changed

- records a stable V3 processing trace across upload arrival, burst collection, image quality, OCR attempts, authorisation, relay activation, and delivery
- carries bounded, redacted telemetry through the durable SQLite outbox without putting extra network work on the gate-opening path
- persists frame quality measurements and upstream timing boundaries needed to diagnose night, glare, blur, and slow-opening failures
- adds bounded JSON/CSV diagnostic export with stable keyset pagination, retention rules, atomic output, and database alias protection
- hardens actuation and outbox finalisation so telemetry failures cannot suppress or duplicate a gate command

## Why

The current system provides little evidence about where a slow or failed recognition spent its time. These measurements make the new operational analytics useful while keeping relay activation local, auditable, and independent of cloud availability.

## Validation

- full pinned dependency suite after rebasing current `master`: 306 passed, 1 expected macOS `flock` skip
- `python3 -m compileall -q gate_controller tests`: passed
- `git diff --check origin/master...HEAD`: passed

## Safety and rollout

- no hold-open behavior is implemented
- no production deployment has been performed from this branch
- merge and deploy the matching web telemetry consumer/migrations before expecting complete cloud analytics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed telemetry for gate processing, including frame quality, OCR attempts, timing, decisions, and actuation.
  * Added secure JSON and CSV telemetry exports with time-range filtering.
  * Added the `telemetry-export` command-line option.
* **Bug Fixes**
  * Improved delivery reliability with retries, fallback payloads, duplicate protection, and delivery tracking.
  * Preserved processing status and telemetry when events are skipped or encounter failures.
* **Chores**
  * Added automatic cleanup of delivered telemetry after the retention period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->