### PR TITLE
Identify Cloudflare controller requests

### DIFF
--- a/gate_controller/cloudflare_client.py
+++ b/gate_controller/cloudflare_client.py
@@ -102,6 +102,7 @@ class CloudflareServiceClient:
         headers = {
             "CF-Access-Client-Id": self.client_id,
             "CF-Access-Client-Secret": self.client_secret,
+            "User-Agent": "gate-controller/1",
         }
         if additional_headers:
             headers.update(additional_headers)

--- a/tests/test_cloudflare_client.py
+++ b/tests/test_cloudflare_client.py
@@ -71,6 +71,7 @@ class CloudflareServiceClientTests(unittest.TestCase):
         self.assertEqual(result, {"plates": []})
         self.assertEqual(session.requests[0].headers["CF-Access-Client-Id"], "client-id")
         self.assertEqual(session.requests[0].headers["CF-Access-Client-Secret"], "client-secret")
+        self.assertEqual(session.requests[0].headers["User-Agent"], "gate-controller/1")
         self.assertEqual(session.requests[0].timeout, (1, 2))
         self.assertFalse(session.requests[0].allow_redirects)
 


### PR DESCRIPTION
## Summary
- add an explicit gate-controller User-Agent to Cloudflare service requests
- cover the header alongside Access service-token headers

## Verification
- python3.11 temp venv: python -m unittest discover -s tests -v (382 tests, 2 skipped)
- python3.11 temp venv on fresh branch: python -m unittest tests.test_cloudflare_client -v
- python3.11 temp venv on fresh branch: python -m compileall -q gate_controller deployment tests scripts
- bash -n deployment/install.sh
- sh -n file_monitor.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cloudflare service requests now include a consistent application identifier in the `User-Agent` header.
* **Tests**
  * Added coverage to verify the expected request header is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->