### PR TITLE
Keep release verifier SGID-safe

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -572,6 +572,14 @@ install() {{
       -o|-g)
         shift 2
         ;;
+      -m)
+        if [[ $2 == 2770 ]]; then
+          forwarded+=("-m" "0770")
+        else
+          forwarded+=("$1" "$2")
+        fi
+        shift 2
+        ;;
       *)
         forwarded+=("$1")
         shift


### PR DESCRIPTION
## Summary
- keep the deployment test's production command assertion for upload mode 2770
- avoid applying SGID in the test mock so candidate verification passes under the updater service's RestrictSUIDSGID sandbox

## Verification
- python3 -m unittest tests.test_deployment.BootstrapInstallerTests.test_configures_shared_upload_directory_and_verifies_account_access -v
- python3 -m compileall -q gate_controller deployment tests scripts
- sh -n file_monitor.sh
- bash -n deployment/install.sh
- Pi transient hardened systemd verifier: unittest discover, compileall, sh -n, bash -n all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment test behavior to correctly handle setgid directory permissions during upload operations.
  * Preserved existing handling for other permission modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->