### PR TITLE
Tolerate retired legacy command unit

### DIFF
--- a/deployment/gate_controller_updater.py
+++ b/deployment/gate_controller_updater.py
@@ -559,11 +559,17 @@ def _systemctl_is(state: str, service_name: str) -> bool:
     if completed.returncode == 0:
         return True
     result = (completed.stdout or "").strip().lower()
+    diagnostic = (completed.stderr or "").strip().lower()
     confirmed_not_present = {
         "is-enabled": {"disabled", "indirect", "masked", "not-found", "static"},
         "is-active": {"failed", "inactive", "not-found"},
     }
     if result in confirmed_not_present.get(state, set()):
+        return False
+    missing_unit_diagnostic = (
+        f"failed to get unit file state for {service_name}: no such file or directory"
+    )
+    if state == "is-enabled" and diagnostic == missing_unit_diagnostic:
         return False
     raise UpdateError(
         f"could not determine whether {service_name} is {state}: {result or 'unknown'}"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -17,6 +17,7 @@ from deployment.gate_controller_updater import (
     _atomic_write,
     _command_environment,
     _legacy_command_state,
+    _systemctl_is,
     activate_release,
     decide_update,
     discover_current_sha,
@@ -313,6 +314,45 @@ class ActivationRecoveryTests(unittest.TestCase):
             ],
             calls,
         )
+
+    def test_legacy_probe_treats_missing_unit_file_as_not_enabled(self):
+        responses = [
+            subprocess.CompletedProcess(
+                [],
+                1,
+                stdout="",
+                stderr=(
+                    "Failed to get unit file state for "
+                    "gate-command-server.service: No such file or directory\n"
+                ),
+            ),
+            subprocess.CompletedProcess([], 3, stdout="inactive\n", stderr=""),
+        ]
+
+        def return_missing_unit(arguments, **_options):
+            return responses.pop(0)
+
+        with patch(
+            "deployment.gate_controller_updater.subprocess.run",
+            side_effect=return_missing_unit,
+        ):
+            state = _legacy_command_state()
+
+        self.assertFalse(state.enabled)
+        self.assertFalse(state.active)
+
+    def test_legacy_probe_rejects_unrelated_missing_file_diagnostics(self):
+        with patch(
+            "deployment.gate_controller_updater.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                [],
+                1,
+                stdout="",
+                stderr="systemctl: /run/dbus/system_bus_socket: No such file or directory\n",
+            ),
+        ):
+            with self.assertRaises(UpdateError):
+                _systemctl_is("is-enabled", "gate-command-server.service")
 
     def test_legacy_probe_timeout_raises_update_error(self):
         with patch(


### PR DESCRIPTION
## Summary
- classify the exact systemd missing-unit-file diagnostic for the retired legacy command service as not enabled
- keep unrelated missing-file diagnostics fail-closed

## Verification
- python3 -m unittest tests.test_updater.ActivationRecoveryTests.test_legacy_probe_treats_missing_unit_file_as_not_enabled tests.test_updater.ActivationRecoveryTests.test_legacy_probe_rejects_unrelated_missing_file_diagnostics tests.test_updater.ActivationRecoveryTests.test_legacy_probe_recognises_confirmed_inactive_and_not_found_states tests.test_updater.ActivationRecoveryTests.test_activation_retires_legacy_command_service_before_restarting_candidate -v
- python3 -m unittest tests.test_deployment.BootstrapInstallerTests.test_configures_shared_upload_directory_and_verifies_account_access -v
- python3 -m compileall -q gate_controller deployment tests scripts
- sh -n file_monitor.sh
- bash -n deployment/install.sh
- git diff --check
- Pi transient hardened systemd verifier with this patch: unittest discover, compileall, sh -n, bash -n all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service status detection when a systemd unit file is missing.
  * Missing services are now correctly recognized as disabled or inactive.
  * Unrecognized systemd diagnostics continue to raise an appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->