### PR TITLE
Use compact Git ref for updater release discovery

### DIFF
--- a/deployment/gate_controller_updater.py
+++ b/deployment/gate_controller_updater.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import http.client
 import json
 import logging
 import os
@@ -266,7 +267,12 @@ def _github_json(config: UpdateConfig, endpoint: str) -> object:
             request, timeout=config.request_timeout_seconds
         ) as response:
             content = response.read(MAX_API_RESPONSE_BYTES + 1)
-    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as error:
+    except (
+        http.client.IncompleteRead,
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        TimeoutError,
+    ) as error:
         raise UpdateError(f"GitHub API request deferred: {error}") from error
     if len(content) > MAX_API_RESPONSE_BYTES:
         raise UpdateError("GitHub API response exceeded the size limit")
@@ -278,7 +284,17 @@ def _github_json(config: UpdateConfig, endpoint: str) -> object:
 
 def _main_commit_payload(config: UpdateConfig) -> object:
     branch = urllib.parse.quote(config.branch, safe="")
-    return _github_json(config, f"commits/{branch}")
+    payload = _github_json(config, f"git/ref/heads/{branch}")
+    expected_ref = f"refs/heads/{config.branch}"
+    if not isinstance(payload, dict) or payload.get("ref") != expected_ref:
+        raise UpdateError("GitHub API returned a mismatched branch ref")
+    target = payload.get("object")
+    if not isinstance(target, dict) or target.get("type") != "commit":
+        raise UpdateError("GitHub branch ref did not target a commit")
+    sha = target.get("sha")
+    if not isinstance(sha, str) or SHA_PATTERN.fullmatch(sha) is None:
+        raise UpdateError("GitHub branch ref did not contain a valid commit SHA")
+    return {"sha": sha}
 
 
 def _workflow_runs_payload(config: UpdateConfig, sha: str) -> object:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,3 +1,4 @@
+import http.client
 import json
 import os
 import subprocess
@@ -16,6 +17,8 @@ from deployment.gate_controller_updater import (
     _atomic_symlink,
     _atomic_write,
     _command_environment,
+    _github_json,
+    _main_commit_payload,
     _legacy_command_state,
     _systemctl_is,
     activate_release,
@@ -59,6 +62,60 @@ def workflow_run(
 
 
 class MainCommitTests(unittest.TestCase):
+    def test_fetches_encoded_branch_ref_and_normalizes_commit_sha(self):
+        config = UpdateConfig.from_mapping(
+            {"GATE_UPDATE_BRANCH": "release/2026.08"}
+        )
+        payload = {
+            "ref": "refs/heads/release/2026.08",
+            "object": {
+                "sha": TARGET_SHA,
+                "type": "commit",
+                "url": "https://api.github.test/commits/candidate",
+            },
+            "url": "https://api.github.test/refs/heads/release/2026.08",
+        }
+
+        with patch(
+            "deployment.gate_controller_updater._github_json",
+            return_value=payload,
+        ) as github_json:
+            result = _main_commit_payload(config)
+
+        self.assertEqual({"sha": TARGET_SHA}, result)
+        github_json.assert_called_once_with(
+            config, "git/ref/heads/release%2F2026.08"
+        )
+
+    def test_rejects_malformed_or_mismatched_branch_ref_payload(self):
+        config = UpdateConfig.from_mapping({})
+        valid_object = {"sha": TARGET_SHA, "type": "commit"}
+        invalid_payloads = (
+            [],
+            {},
+            {"ref": "refs/heads/other", "object": valid_object},
+            {"ref": "refs/heads/master", "object": []},
+            {
+                "ref": "refs/heads/master",
+                "object": {"sha": TARGET_SHA, "type": "tag"},
+            },
+            {
+                "ref": "refs/heads/master",
+                "object": {"sha": "abc", "type": "commit"},
+            },
+            {
+                "ref": "refs/heads/master",
+                "object": {"sha": "A" * 40, "type": "commit"},
+            },
+        )
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload), patch(
+                "deployment.gate_controller_updater._github_json",
+                return_value=payload,
+            ), self.assertRaises(UpdateError):
+                _main_commit_payload(config)
+
     def test_reads_exact_lowercase_commit_sha(self):
         self.assertEqual(TARGET_SHA, read_main_sha({"sha": TARGET_SHA}))
 
@@ -67,6 +124,28 @@ class MainCommitTests(unittest.TestCase):
             with self.subTest(payload=payload):
                 with self.assertRaises(ValueError):
                     read_main_sha(payload)
+
+    def test_incomplete_github_response_is_deferred_as_update_error(self):
+        class IncompleteResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, _exception_type, _exception, _traceback):
+                return False
+
+            def read(self, _limit):
+                raise http.client.IncompleteRead(b'{"ref":', 128)
+
+        config = UpdateConfig.from_mapping({})
+        with patch(
+            "deployment.gate_controller_updater.urllib.request.urlopen",
+            return_value=IncompleteResponse(),
+        ), self.assertRaisesRegex(
+            UpdateError, "GitHub API request deferred"
+        ) as raised:
+            _github_json(config, "git/ref/heads/master")
+
+        self.assertIsInstance(raised.exception.__cause__, http.client.IncompleteRead)
 
 
 class WorkflowDecisionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- discover the protected branch head through GitHub's compact Git ref endpoint
- validate the exact branch ref, commit target type, and immutable SHA before preserving the existing updater decision contract
- treat truncated chunked API responses as a deferred poll instead of crashing the systemd updater unit

## Production evidence
The Pi remained on the previous healthy release when the large single-commit response was truncated during `response.read()`. The branch ref response is only a few hundred bytes and avoids transferring commit patches that release discovery does not use.

## Verification
- updater tests: 48 passed
- full pytest: 532 passed, 3 skipped, 377 subtests passed
- full unittest: 535 passed, 3 skipped
- ShellCheck, shell syntax, compileall, and diff checks pass
- independent review clean

No gate actuation or Pi changes are part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving branch commit information from GitHub.
  * Updates are now deferred safely when responses are incomplete.
  * Invalid, mismatched, or malformed commit data is rejected to prevent unsafe updates.

* **Tests**
  * Added coverage for encoded branch names, invalid commit references, and incomplete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->