### PR TITLE
Stabilize processor close concurrency test on Pi

### DIFF
--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1544,6 +1544,7 @@ class GateProcessorTests(unittest.TestCase):
     def test_processor_close_terminally_inhibits_an_in_flight_exact_match(self):
         recognising = Event()
         release = Event()
+        completed = Event()
 
         class LateExactRecognizer:
             def recognise(self, path, timeout=None):
@@ -1552,25 +1553,46 @@ class GateProcessorTests(unittest.TestCase):
                 return PlateObservation("12D3456", 0.99)
 
         results = []
+        worker_errors = []
         relay_calls = []
         with tempfile.TemporaryDirectory() as directory:
             processor = self._processor(
                 LocalStore(Path(directory) / "gate.db"), RecordingRelay(relay_calls),
                 LateExactRecognizer(), decision_timeout=2.0,
             )
+
+            def process_in_flight_match():
+                try:
+                    results.append(
+                        processor.process(
+                            (self._jpeg(directory, "close-exact.jpg"),)
+                        )
+                    )
+                except BaseException as error:
+                    worker_errors.append(error)
+                finally:
+                    completed.set()
+
             worker = Thread(
-                target=lambda: results.append(
-                    processor.process((self._jpeg(directory, "close-exact.jpg"),))
-                ),
+                target=process_in_flight_match,
                 daemon=True,
             )
             worker.start()
-            self.assertTrue(recognising.wait(0.5))
-            processor.close()
-            release.set()
-            worker.join(1.0)
+            try:
+                self.assertTrue(recognising.wait(5.0))
+                processor.close()
+                release.set()
+                self.assertTrue(completed.wait(5.0))
+            finally:
+                try:
+                    processor.close()
+                finally:
+                    release.set()
+                    completed.wait(5.0)
+                    worker.join(1.0)
 
         self.assertFalse(worker.is_alive())
+        self.assertEqual(worker_errors, [])
         self.assertEqual(len(results), 1)
         self.assertFalse(results[0].opened)
         self.assertEqual(results[0].reason, "processor_closed")


### PR DESCRIPTION
## Summary
- replace a scheduler-sensitive one-second join with explicit bounded completion signalling
- capture worker exceptions and guarantee close/release/join cleanup
- preserve the production-safety assertions: terminal `processor_closed` denial and zero relay calls

## Why
The trusted bootstrap runs the full suite on the Raspberry Pi. Under that machine's suite load, this test occasionally left its outer worker alive after the fixed one-second join even though the production behavior was correct. The installer correctly stopped before activation, leaving the previous healthy release active.

## Verification
- focused test repeated 75/75
- `pytest`: 532 passed, 3 skipped, 377 subtests
- `unittest`: 535 passed, 3 skipped
- shellcheck and shell syntax checks passed
- compileall and diff checks passed
- independent review: clean

No Pi services or gate relay were touched by this test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for processing after the processor is closed.
  * Added reliable handling of background processing completion and errors.
  * Verified that closed-processor requests are denied without activating the relay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->