### PR TITLE
Harden progressive Reolink recognition finalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,16 @@ rejected. Set `GATE_REOLINK_SNAPSHOT_ALLOW_SELF_SIGNED=true` only for a camera
 with a deliberately accepted self-signed certificate on that private address.
 
 The default captures two sequential additional snapshots under one 2.25-second
-global deadline. `GATE_REOLINK_SNAPSHOT_COUNT` is limited to 1-4,
+end-to-end wall-clock deadline. `GATE_REOLINK_SNAPSHOT_COUNT` is limited to 1-4,
 `GATE_REOLINK_SNAPSHOT_TIMEOUT_SECONDS` is limited to 3 seconds, and
 `GATE_REOLINK_SNAPSHOT_MAX_BYTES` cannot exceed the configured candidate-image
-limit. Generated JPEGs live in an ignored owner-only subdirectory and enter the
-same ranking and OCR path as a separate progressive burst carrying the original
-FTP `received_at`; they never authorize directly. A login, snapshot, validation,
-timeout, or cleanup failure leaves the already-released FTP burst unchanged.
+limit. Generated JPEGs live in an ignored owner-only directory beneath the FTP
+upload root. The first FTP image enters recognition immediately and establishes
+one durable trigger identity. An authorizing result finalizes immediately; only
+an improvable denial waits for snapshots, which reuse that identity and its
+single actuation claim. Login, snapshot, validation, timeout, and shutdown
+failures terminally record the original FTP result. Snapshot sampling itself has
+no actuation path.
 Logs record `source=camera_ftp subtype=unverified` and
 `augmentation=reolink_snapshot` without camera credentials or token values.
 

--- a/docs/reolink-rlc-810a.md
+++ b/docs/reolink-rlc-810a.md
@@ -73,17 +73,18 @@ hostname verification. A hostile device on the camera LAN could then impersonate
 the camera and capture its credentials. Enable it only when the camera cannot use
 a certificate verifiable by the Pi, and keep the camera network tightly scoped.
 
-The default takes two additional 4K snapshots sequentially under one global
-2.25-second deadline. They are written temporarily beneath the upload root in
-an ignored owner-only `.reolink-snapshots` directory, validated as bounded
-JPEGs, and added together to a separate progressive OCR burst with the original
-FTP `received_at`. Generated files cannot recursively request another sample.
-They use the existing ranking, recognition, authorization, durable actuation
-claim, and cooldown path; a camera trigger or snapshot never actuates the relay
-by itself. A plate recognized from either the primary FTP image or a later
-snapshot can open the gate only after the same authorization, claim, cooldown,
-and relay-safety checks succeed. Failure or unavailable configuration leaves the
-first FTP attempt and its normal quiet window unchanged.
+The default takes two additional 4K snapshots sequentially under one end-to-end
+2.25-second wall-clock deadline. They are written temporarily beneath the upload
+root in an ignored owner-only `.reolink-snapshots` directory and validated as
+bounded JPEGs. The first FTP image enters recognition on its normal quiet window
+and establishes one durable trigger identity. An authorizing FTP result
+finalizes immediately; only an improvable denial waits for snapshots, which
+reuse that identity and its single actuation claim. Generated files cannot
+recursively request another sample, and snapshot sampling has no relay path. A
+plate from either the primary FTP image or a later snapshot can open the gate
+only after the same authorization, claim, cooldown, and relay-safety checks
+succeed. Failure, timeout, shutdown, or unavailable configuration terminally
+finalizes the original FTP result.
 
 Do not configure on-demand ffmpeg sampling from
 `rtsp://127.0.0.1:8554/camera` for this feature. Live Pi measurements took

--- a/gate_controller/__main__.py
+++ b/gate_controller/__main__.py
@@ -101,7 +101,8 @@ def main() -> None:
     )
 
     def process(paths, received_at=None, decision_started_at=None,
-                processing_started_at=None):
+                processing_started_at=None, *, idempotency_key=None, final=True,
+                provisional_result=None):
         latest_image["path"] = str(paths[0]) if paths else None
         latest_image["received_at"] = (received_at or datetime.now(timezone.utc)).isoformat()
         return processor.process(
@@ -109,6 +110,9 @@ def main() -> None:
             received_at=received_at,
             decision_started_at=decision_started_at,
             processing_started_at=processing_started_at,
+            idempotency_key=idempotency_key,
+            final=final,
+            provisional_result=provisional_result,
         )
 
     def record_skipped(paths, reason, received_at, decision_started_at=None,

--- a/gate_controller/images.py
+++ b/gate_controller/images.py
@@ -35,7 +35,7 @@ def is_decodable_jpeg(data: bytes) -> bool:
 
 def measure_frame_quality(path: Path, *, digest: str | None = None) -> FrameTelemetry:
     """Return bounded, downsampled quality proxies without exposing image paths."""
-    path = Path(path)
+    path = _image_source(path)
     if digest is None:
         try:
             digest = _content_digest(path)
@@ -47,14 +47,15 @@ def measure_frame_quality(path: Path, *, digest: str | None = None) -> FrameTele
             raise ValueError("invalid image signature")
         with warnings.catch_warnings():
             warnings.simplefilter("error", Image.DecompressionBombWarning)
-            with Image.open(path) as image:
-                if image.format != "JPEG":
-                    raise ValueError("invalid image format")
-                width, height = image.size
-                image.draft("L", QUALITY_SIZE)
-                image.load()
-                image.thumbnail(QUALITY_SIZE, Image.Resampling.BILINEAR)
-                grayscale = image.convert("L")
+            with path.open("rb") as source:
+                with Image.open(source) as image:
+                    if image.format != "JPEG":
+                        raise ValueError("invalid image format")
+                    width, height = image.size
+                    image.draft("L", QUALITY_SIZE)
+                    image.load()
+                    image.thumbnail(QUALITY_SIZE, Image.Resampling.BILINEAR)
+                    grayscale = image.convert("L")
 
         histogram = grayscale.histogram()
         pixel_count = max(sum(histogram), 1)
@@ -110,7 +111,7 @@ def _sharpness_proxy(grayscale: Image.Image) -> float:
 
 def wait_until_readable(path: Path, timeout: float, poll_interval: float = 0.1) -> bool:
     """Wait for a complete, decodable image without treating partial uploads as valid."""
-    path = Path(path)
+    path = _image_source(path)
     deadline = monotonic() + max(timeout, 0)
     while True:
         if _is_valid_image(path):
@@ -124,7 +125,7 @@ def rank_images(paths, *, max_bytes: int | None = None) -> list[Path]:
     """Return valid images ordered from sharpest to least sharp."""
     scored_paths = []
     for path in paths:
-        path = Path(path)
+        path = _image_source(path)
         try:
             if max_bytes is not None and path.stat().st_size > max_bytes:
                 continue
@@ -132,13 +133,14 @@ def rank_images(paths, *, max_bytes: int | None = None) -> list[Path]:
                 continue
             with warnings.catch_warnings():
                 warnings.simplefilter("error", Image.DecompressionBombWarning)
-                with Image.open(path) as image:
-                    if image.format != "JPEG":
-                        continue
-                    image.load()
-                    grayscale = image.convert("L")
-                    edges = grayscale.filter(ImageFilter.FIND_EDGES)
-                    sharpness = ImageStat.Stat(edges).var[0]
+                with path.open("rb") as source:
+                    with Image.open(source) as image:
+                        if image.format != "JPEG":
+                            continue
+                        image.load()
+                        grayscale = image.convert("L")
+                        edges = grayscale.filter(ImageFilter.FIND_EDGES)
+                        sharpness = ImageStat.Stat(edges).var[0]
         except (
             OSError, ValueError, Image.DecompressionBombWarning, Image.DecompressionBombError,
         ):
@@ -149,6 +151,7 @@ def rank_images(paths, *, max_bytes: int | None = None) -> list[Path]:
 
 def _content_digest(path: Path) -> str:
     digest = hashlib.sha256()
+    path = _image_source(path)
     with path.open("rb") as source:
         for chunk in iter(lambda: source.read(1024 * 1024), b""):
             digest.update(chunk)
@@ -156,15 +159,17 @@ def _content_digest(path: Path) -> str:
 
 
 def _is_valid_image(path: Path) -> bool:
+    path = _image_source(path)
     if not _has_jpeg_signature(path):
         return False
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("error", Image.DecompressionBombWarning)
-            with Image.open(path) as image:
-                if image.format != "JPEG":
-                    return False
-                image.verify()
+            with path.open("rb") as source:
+                with Image.open(source) as image:
+                    if image.format != "JPEG":
+                        return False
+                    image.verify()
         return True
     except (
         OSError, ValueError, Image.DecompressionBombWarning, Image.DecompressionBombError,
@@ -174,7 +179,13 @@ def _is_valid_image(path: Path) -> bool:
 
 def _has_jpeg_signature(path: Path) -> bool:
     try:
-        with Path(path).open("rb") as source:
+        with _image_source(path).open("rb") as source:
             return source.read(3) == b"\xff\xd8\xff"
     except OSError:
         return False
+
+
+def _image_source(path):
+    if getattr(path, "_descriptor_anchored", False):
+        return path
+    return Path(path)

--- a/gate_controller/models.py
+++ b/gate_controller/models.py
@@ -79,3 +79,5 @@ class ProcessingResult:
     event_id: int | None = None
     decision: MatchDecision | None = None
     telemetry: EventTelemetry | None = None
+    idempotency_key: str | None = None
+    terminal: bool = True

--- a/gate_controller/outbox.py
+++ b/gate_controller/outbox.py
@@ -37,11 +37,11 @@ class EvidenceSpool:
     def __init__(self, root: Path):
         self.root = Path(root)
 
-    def stage(self, source_path: Path) -> str:
+    def stage(self, source_path) -> str:
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("error", Image.DecompressionBombWarning)
-                encoded = _normalise_jpeg(Path(source_path))
+                encoded = _normalise_jpeg(source_path)
         except Exception as error:
             raise EvidenceSpoolError(
                 f"could not prepare JPEG evidence: {source_path}"
@@ -205,18 +205,20 @@ def _is_ingest_acknowledgement(value: object) -> bool:
     )
 
 
-def _normalise_jpeg(path: Path) -> bytes | None:
-    if not path.is_file() or not _has_jpeg_signature(path):
-        return None
-    with Image.open(path) as source:
-        if source.format != "JPEG":
+def _normalise_jpeg(source_path) -> bytes | None:
+    with source_path.open("rb") as source_file:
+        if source_file.read(3) != b"\xff\xd8\xff":
             return None
-        image = ImageOps.exif_transpose(source).convert("RGB")
-        image.thumbnail(
-            (MAX_OUTBOX_IMAGE_DIMENSION, MAX_OUTBOX_IMAGE_DIMENSION),
-            Image.Resampling.LANCZOS,
-        )
-        return _bounded_jpeg(image)
+        source_file.seek(0)
+        with Image.open(source_file) as source:
+            if source.format != "JPEG":
+                return None
+            image = ImageOps.exif_transpose(source).convert("RGB")
+            image.thumbnail(
+                (MAX_OUTBOX_IMAGE_DIMENSION, MAX_OUTBOX_IMAGE_DIMENSION),
+                Image.Resampling.LANCZOS,
+            )
+            return _bounded_jpeg(image)
 
 
 def _bounded_jpeg(image: Image.Image) -> bytes | None:
@@ -234,14 +236,6 @@ def _bounded_jpeg(image: Image.Image) -> bytes | None:
             break
         working = working.resize((width, height), Image.Resampling.LANCZOS)
     return None
-
-
-def _has_jpeg_signature(path: Path) -> bool:
-    try:
-        with Path(path).open("rb") as source:
-            return source.read(3) == b"\xff\xd8\xff"
-    except OSError:
-        return False
 
 
 class TelemetryRetentionWorker:

--- a/gate_controller/processor.py
+++ b/gate_controller/processor.py
@@ -17,7 +17,7 @@ from .actuation import ActuationCoordinator
 from .images import measure_frame_quality
 from .matching import decide_access, normalise_plate
 from .models import GateEvent, ProcessingResult
-from .telemetry import OcrAttemptTelemetry, ProcessingTrace
+from .telemetry import AugmentationTelemetry, OcrAttemptTelemetry, ProcessingTrace
 
 
 MAX_OCR_FRAMES = 3
@@ -25,6 +25,9 @@ DEFAULT_ACTIVATION_GUARD_SECONDS = 0.1
 FINAL_INHIBITION_REASONS = frozenset({
     "stale_burst", "authorisation_error", "authorisation_revoked",
     "decision_timeout", "processor_closed",
+})
+IMPROVABLE_DENIAL_REASONS = frozenset({
+    "ambiguous_fuzzy_match", "no_match", "ocr_busy", "ocr_error",
 })
 
 
@@ -81,22 +84,48 @@ class GateProcessor:
 
     def process(self, paths: Iterable[Path], received_at: datetime | None = None,
                 decision_started_at: float | None = None,
-                processing_started_at: datetime | None = None) -> ProcessingResult:
+                processing_started_at: datetime | None = None, *,
+                idempotency_key: str | None = None,
+                final: bool = True,
+                provisional_result: ProcessingResult | None = None,
+                augmentation: AugmentationTelemetry | dict | None = None) -> ProcessingResult:
+        augmentation = _augmentation_telemetry(augmentation)
+        if provisional_result is not None:
+            provisional_key = provisional_result.idempotency_key
+            if (
+                not final
+                or provisional_result.terminal
+                or not provisional_key
+                or (idempotency_key is not None and idempotency_key != provisional_key)
+            ):
+                raise ValueError("invalid provisional processing result")
+            return self._terminalize_provisional_result(
+                paths, provisional_result, received_at,
+                augmentation=augmentation,
+            )
         started = self._decision_clock() if decision_started_at is None else decision_started_at
         deadline = started + self._decision_timeout
         activation_deadline = deadline - self._activation_guard_seconds
-        candidates = _unique_content_candidates(tuple(Path(path) for path in paths))
+        candidates = _unique_content_candidates(
+            tuple(_candidate_path(path) for path in paths)
+        )
         paths = tuple(path for path, _digest in candidates)
         digests = tuple(digest for _path, digest in candidates)
-        idempotency_key = _event_key_from_digests(digests)
+        idempotency_key = idempotency_key or _event_key_from_digests(digests)
         if self._store.event_exists(idempotency_key):
             if self._outbox_enabled:
                 event_id = self._store.terminal_outcome(idempotency_key)
                 event_id = event_id.event_id if event_id else self._store.event_id(idempotency_key)
                 if event_id is not None:
                     self._store.ensure_outbox(event_id, self._outbox_payload(paths))
-            return ProcessingResult(False, self._store.actuation_claim_status(idempotency_key) or "duplicate_event")
+            return ProcessingResult(
+                False,
+                self._store.actuation_claim_status(idempotency_key) or "duplicate_event",
+                self._store.event_id(idempotency_key),
+                idempotency_key=idempotency_key,
+            )
         trace = self._new_trace()
+        trace.set_augmentation(augmentation)
         if (
             received_at is not None
             or decision_started_at is not None
@@ -199,6 +228,15 @@ class GateProcessor:
             timed_out = True
         if decision is None:
             reason = "decision_timeout" if timed_out else (ocr_failure_reason or "no_match")
+            if not final and reason in IMPROVABLE_DENIAL_REASONS:
+                trace.mark_decision("denied", reason)
+                return self._finish_result(
+                    trace,
+                    ProcessingResult(
+                        False, reason, idempotency_key=idempotency_key,
+                        terminal=False,
+                    ),
+                )
             return self.record_skipped(
                 paths, reason, received_at, trace=trace,
                 idempotency_key=idempotency_key,
@@ -210,7 +248,10 @@ class GateProcessor:
                                   decision)
             event_id = self._record(event, paths)
             return self._finish_result(
-                trace, ProcessingResult(False, "decision_timeout", event_id, decision)
+                trace, ProcessingResult(
+                    False, "decision_timeout", event_id, decision,
+                    idempotency_key=idempotency_key,
+                )
             )
         if not _is_fresh(decision_at, received_at, self._max_image_age):
             trace.mark_decision("denied", "stale_burst")
@@ -218,7 +259,10 @@ class GateProcessor:
                                   decision)
             event_id = self._record(event, paths)
             return self._finish_result(
-                trace, ProcessingResult(False, "stale_burst", event_id, decision)
+                trace, ProcessingResult(
+                    False, "stale_burst", event_id, decision,
+                    idempotency_key=idempotency_key,
+                )
             )
         event = GateEvent(
             source="ocr", reason=decision.reason, opened=False, idempotency_key=idempotency_key,
@@ -235,9 +279,20 @@ class GateProcessor:
             trace.mark_decision("allowed", decision.reason)
         outbox_payload = self._outbox_payload(paths, await_telemetry=True)
         if not decision.allowed:
+            if not final and event.reason in IMPROVABLE_DENIAL_REASONS:
+                return self._finish_result(
+                    trace,
+                    ProcessingResult(
+                        False, event.reason, decision=decision,
+                        idempotency_key=idempotency_key, terminal=False,
+                    ),
+                )
             event_id = self._store.record_event_with_outbox(event, outbox_payload)
             return self._finish_result(
-                trace, ProcessingResult(False, event.reason, event_id, decision)
+                trace, ProcessingResult(
+                    False, event.reason, event_id, decision,
+                    idempotency_key=idempotency_key,
+                )
             )
         actuation_at = self._clock()
         if not _is_fresh(actuation_at, received_at, self._max_image_age):
@@ -246,7 +301,10 @@ class GateProcessor:
             )
             event_id = self._store.record_event_with_outbox(event, outbox_payload)
             return self._finish_result(
-                trace, ProcessingResult(False, "stale_burst", event_id, decision)
+                trace, ProcessingResult(
+                    False, "stale_burst", event_id, decision,
+                    idempotency_key=idempotency_key,
+                )
             )
         def activation_inhibition():
             with self._ocr_slot_lock:
@@ -281,7 +339,10 @@ class GateProcessor:
         trace.set_actuation_outcome(*_actuation_telemetry(execution))
         return self._finish_result(
             trace,
-            ProcessingResult(execution.opened, execution.reason, execution.event_id, decision),
+            ProcessingResult(
+                execution.opened, execution.reason, execution.event_id, decision,
+                idempotency_key=idempotency_key,
+            ),
         )
 
     def record_skipped(self, paths: Iterable[Path], reason: str,
@@ -290,7 +351,7 @@ class GateProcessor:
                        idempotency_key: str | None = None, *,
                        decision_started_at: float | None = None,
                        processing_started_at: datetime | None = None) -> ProcessingResult:
-        paths = tuple(Path(path) for path in paths)
+        paths = tuple(_candidate_path(path) for path in paths)
         idempotency_key = idempotency_key or _event_key(paths)
         if self._store.event_exists(idempotency_key):
             event_id = self._store.event_id(idempotency_key)
@@ -300,6 +361,7 @@ class GateProcessor:
                 False,
                 self._store.actuation_claim_status(idempotency_key) or "duplicate_event",
                 event_id,
+                idempotency_key=idempotency_key,
             )
         if trace is None:
             trace = self._new_trace()
@@ -322,8 +384,45 @@ class GateProcessor:
             received_at=received_at or self._clock(), decision_at=self._clock(),
         )
         event_id = self._record(event, paths)
-        result = ProcessingResult(False, reason, event_id)
+        result = ProcessingResult(
+            False, reason, event_id, idempotency_key=idempotency_key
+        )
         return self._finish_result(trace, result)
+
+    def _terminalize_provisional_result(
+        self, paths: Iterable[Path], provisional_result: ProcessingResult,
+        received_at: datetime | None, *, augmentation: AugmentationTelemetry | None,
+    ) -> ProcessingResult:
+        decision = provisional_result.decision
+        event = GateEvent(
+            source="ocr", reason=provisional_result.reason, opened=False,
+            idempotency_key=provisional_result.idempotency_key,
+            received_at=received_at or self._clock(), decision_at=self._clock(),
+            authorised_plate=decision.authorised_plate if decision else None,
+            observed_plate=decision.observed_plate if decision else None,
+            ocr_confidence=decision.confidence if decision else 0.0,
+        )
+        event_id = self._record(event, paths)
+        telemetry = provisional_result.telemetry
+        if telemetry is not None and augmentation is not None:
+            telemetry = replace(telemetry, augmentation=augmentation)
+        result = ProcessingResult(
+            False, provisional_result.reason, event_id, decision,
+            telemetry=telemetry,
+            idempotency_key=provisional_result.idempotency_key,
+        )
+        if telemetry is None:
+            self._release_outbox_without_telemetry(event_id)
+            return result
+        _log_completed_trace(telemetry)
+        try:
+            self._store.attach_event_telemetry(event_id, telemetry)
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "event_telemetry_attach status=persistence_failed"
+            )
+            self._release_outbox_without_telemetry(event_id)
+        return result
 
     def _finish_result(
         self, trace: _BestEffortTrace, result: ProcessingResult
@@ -370,7 +469,7 @@ class GateProcessor:
     ) -> dict | None:
         if not self._outbox_enabled:
             return None
-        paths = tuple(Path(path) for path in paths)
+        paths = tuple(_candidate_path(path) for path in paths)
         prepare_payload = getattr(self._outbox, "prepare_payload", None)
         if not callable(prepare_payload):
             payload = {"event_id": None}
@@ -528,6 +627,13 @@ class _BestEffortTrace:
     def mark_burst(self) -> None:
         self._call("mark_burst")
 
+    def set_augmentation(self, augmentation) -> None:
+        if self._trace is None:
+            return
+        operation = getattr(self._trace, "set_augmentation", None)
+        if callable(operation):
+            self._call("set_augmentation", augmentation)
+
     def seed_upstream(
         self, received_at: datetime | None, decision_started_at: float | None,
         processing_started_at: datetime | None = None,
@@ -594,8 +700,29 @@ def _content_digest(path: Path) -> str:
             for chunk in iter(lambda: source.read(1024 * 1024), b""):
                 digest.update(chunk)
     except OSError:
-        digest.update(f"missing:{path.resolve()}".encode("utf-8"))
+        missing = str(path) if getattr(path, "_descriptor_anchored", False) else path.resolve()
+        digest.update(f"missing:{missing}".encode("utf-8"))
     return digest.hexdigest()
+
+
+def _candidate_path(path):
+    if getattr(path, "_descriptor_anchored", False):
+        return path
+    return Path(path)
+
+
+def _augmentation_telemetry(value) -> AugmentationTelemetry | None:
+    if value is None or isinstance(value, AugmentationTelemetry):
+        return value
+    if not isinstance(value, dict):
+        return None
+    return AugmentationTelemetry(
+        outcome=value.get("outcome", "failed"),
+        reason=value.get("reason", "unknown"),
+        candidate_count=value.get("candidate_count", 0),
+        duration_ms=value.get("duration_ms", 0),
+        correlation=value.get("correlation"),
+    )
 
 
 def _unique_content_paths(paths: tuple[Path, ...]) -> tuple[Path, ...]:

--- a/gate_controller/reolink_snapshots.py
+++ b/gate_controller/reolink_snapshots.py
@@ -12,13 +12,13 @@ import stat
 from dataclasses import dataclass, field
 from pathlib import Path
 from queue import Empty, Queue
-from threading import Lock
+from threading import Event, Lock, Thread
 from time import monotonic
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode, urlparse
 from urllib.request import HTTPRedirectHandler, HTTPSHandler, Request, build_opener
 
-from .images import is_decodable_jpeg
+from .images import wait_until_readable
 
 
 DEFAULT_REOLINK_SNAPSHOT_COUNT = 2
@@ -54,7 +54,7 @@ class SnapshotResponse:
 @dataclass(frozen=True)
 class ReolinkSnapshotConfig:
     base_url: str | None
-    username: str | None
+    username: str | None = field(repr=False)
     password: str | None = field(repr=False)
     allow_self_signed: bool = False
     candidate_count: int = DEFAULT_REOLINK_SNAPSHOT_COUNT
@@ -326,14 +326,200 @@ def _transport_failure_reason(error: BaseException, fallback: str) -> str:
     return fallback
 
 
+class _SnapshotSpool:
+    """Own a private directory without ever traversing a replacement symlink."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        parent_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        parent_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        parent_fd = os.open(self.path.parent, parent_flags)
+        try:
+            try:
+                entry = os.stat(
+                    self.path.name, dir_fd=parent_fd, follow_symlinks=False
+                )
+            except FileNotFoundError:
+                entry = None
+            if entry is not None and stat.S_ISLNK(entry.st_mode):
+                raise OSError(errno.ELOOP, "snapshot spool must not be a symlink")
+            if entry is not None and not stat.S_ISDIR(entry.st_mode):
+                raise OSError(errno.ENOTDIR, "snapshot spool is not a directory")
+            if entry is None:
+                os.mkdir(self.path.name, mode=0o700, dir_fd=parent_fd)
+            directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+            directory_flags |= (
+                getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            )
+            self._directory_fd = os.open(
+                self.path.name, directory_flags, dir_fd=parent_fd
+            )
+        finally:
+            os.close(parent_fd)
+        if not stat.S_ISDIR(os.fstat(self._directory_fd).st_mode):
+            os.close(self._directory_fd)
+            raise OSError(errno.ENOTDIR, "snapshot spool is not a directory")
+        os.fchmod(self._directory_fd, 0o700)
+        self._closed = False
+
+    def store(self, filename: str, data: bytes):
+        temporary = f"{filename}.part"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=self._directory_fd)
+        try:
+            view = memoryview(data)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError(errno.EIO, "snapshot spool write made no progress")
+                view = view[written:]
+            os.fchmod(descriptor, 0o600)
+        except BaseException:
+            self._unlink(temporary)
+            raise
+        finally:
+            os.close(descriptor)
+        try:
+            os.replace(
+                temporary, filename,
+                src_dir_fd=self._directory_fd, dst_dir_fd=self._directory_fd,
+            )
+        except BaseException:
+            self._unlink(temporary)
+            raise
+        return _AnchoredSnapshot(
+            self._directory_fd, filename, self.path / filename
+        )
+
+    def cleanup_prefix(self, prefix: str, *, keep: set[Path]) -> None:
+        keep_names = {path.name for path in keep}
+        for name in os.listdir(self._directory_fd):
+            if name.startswith(f"{prefix}-") and name not in keep_names:
+                self._unlink_non_directory(name)
+
+    def cleanup_all(self) -> None:
+        for name in os.listdir(self._directory_fd):
+            self._unlink_non_directory(name)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        os.close(self._directory_fd)
+        self._closed = True
+
+    def _unlink_non_directory(self, name: str) -> None:
+        try:
+            entry = os.stat(name, dir_fd=self._directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if stat.S_ISREG(entry.st_mode) or stat.S_ISLNK(entry.st_mode):
+            self._unlink(name)
+
+    def _unlink(self, name: str) -> None:
+        try:
+            os.unlink(name, dir_fd=self._directory_fd)
+        except FileNotFoundError:
+            pass
+
+
+class _AnchoredSnapshot:
+    """A snapshot whose reads and deletion stay pinned to its spool directory."""
+
+    _descriptor_anchored = True
+
+    def __init__(self, directory_fd: int, filename: str, display_path: Path):
+        self._directory_fd = os.dup(directory_fd)
+        self._filename = filename
+        self._display_path = Path(display_path)
+        self._lock = Lock()
+        self._closed = False
+
+    @property
+    def name(self) -> str:
+        return self._filename
+
+    @property
+    def suffix(self) -> str:
+        return Path(self._filename).suffix
+
+    def open(self, mode: str = "rb"):
+        if mode not in {"rb", "br"}:
+            raise ValueError("anchored snapshots are read-only")
+        with self._lock:
+            if self._closed:
+                raise OSError(errno.EBADF, "snapshot candidate is closed")
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(
+                self._filename, flags, dir_fd=self._directory_fd
+            )
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            os.close(descriptor)
+            raise OSError(errno.EINVAL, "snapshot candidate is not a file")
+        return os.fdopen(descriptor, "rb")
+
+    def stat(self):
+        with self._lock:
+            if self._closed:
+                raise OSError(errno.EBADF, "snapshot candidate is closed")
+            result = os.stat(
+                self._filename,
+                dir_fd=self._directory_fd,
+                follow_symlinks=False,
+            )
+        if not stat.S_ISREG(result.st_mode):
+            raise OSError(errno.EINVAL, "snapshot candidate is not a file")
+        return result
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        try:
+            with self._lock:
+                if self._closed:
+                    if missing_ok:
+                        return
+                    raise OSError(errno.EBADF, "snapshot candidate is closed")
+                try:
+                    entry = os.stat(
+                        self._filename,
+                        dir_fd=self._directory_fd,
+                        follow_symlinks=False,
+                    )
+                except FileNotFoundError:
+                    if not missing_ok:
+                        raise
+                else:
+                    if stat.S_ISREG(entry.st_mode) or stat.S_ISLNK(entry.st_mode):
+                        os.unlink(self._filename, dir_fd=self._directory_fd)
+        finally:
+            self.close()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            os.close(self._directory_fd)
+            self._closed = True
+
+    def __str__(self) -> str:
+        return str(self._display_path)
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
 class ReolinkSnapshotSampler:
     """Serially augment one FTP burst without participating in authorization."""
 
-    def __init__(self, config: ReolinkSnapshotConfig, add_candidate, *,
+    def __init__(self, config: ReolinkSnapshotConfig, complete, *,
                  client_factory=ReolinkSnapshotClient, clock=monotonic,
                  run_id=lambda: secrets.token_hex(8)):
         self._config = config
-        self._add_candidate = add_candidate
+        self._complete = complete
         self._client_factory = client_factory
         self._clock = clock
         self._run_id = run_id
@@ -342,8 +528,23 @@ class ReolinkSnapshotSampler:
         self._active = False
         self._started_at: float | None = None
         self._deadline: float | None = None
+        self._wall_deadline: float | None = None
+        self._operation_thread: Thread | None = None
+        self._operation_done: Event | None = None
+        self._operation_cancel: Event | None = None
+        self._cancel_reason: str | None = None
+        self._completion_reported = False
+        self._completion_delivered = False
         self._closed = False
-        self._cleanup_all()
+        self._resources_closed = False
+        self._spool = None
+        if config.enabled:
+            try:
+                self._spool = _SnapshotSpool(config.output_directory)
+            except OSError:
+                pass
+        if self._spool is not None:
+            self._cleanup_all()
 
     @property
     def output_directory(self) -> Path:
@@ -366,17 +567,25 @@ class ReolinkSnapshotSampler:
                 self._active = True
                 self._started_at = started_at
                 self._deadline = started_at + self._config.timeout_seconds
+                self._wall_deadline = monotonic() + self._config.timeout_seconds
+                self._completion_delivered = False
                 self._requests.put_nowait(received_at)
                 return True
         self._log("skipped", 0, reason, 0)
         return False
 
     def run_forever(self, stop_event) -> None:
-        while not stop_event.is_set():
+        while True:
+            if stop_event.is_set():
+                self._complete_queued_shutdown()
+                return
             try:
                 received_at = self._requests.get(timeout=SAMPLER_POLL_SECONDS)
             except Empty:
                 continue
+            if stop_event.is_set():
+                self._complete_without_capture(received_at, "shutdown")
+                return
             self._capture(stop_event, received_at)
 
     def run_once(self, stop_event) -> bool:
@@ -384,31 +593,121 @@ class ReolinkSnapshotSampler:
             received_at = self._requests.get_nowait()
         except Empty:
             return False
+        if stop_event.is_set():
+            self._complete_without_capture(received_at, "shutdown")
+            return True
         self._capture(stop_event, received_at)
         return True
+
+    def _complete_queued_shutdown(self) -> bool:
+        try:
+            received_at = self._requests.get_nowait()
+        except Empty:
+            return False
+        self._complete_without_capture(received_at, "shutdown")
+        return True
+
+    def _complete_without_capture(self, received_at, reason: str) -> None:
+        started_at = self._clock()
+        with self._lock:
+            if self._started_at is not None:
+                started_at = self._started_at
+        try:
+            self._deliver_completion((), received_at)
+        except Exception:
+            reason = "collector_error"
+        finally:
+            with self._lock:
+                self._active = False
+                self._started_at = None
+                self._deadline = None
+                self._wall_deadline = None
+                self._operation_thread = None
+                self._operation_done = None
+                self._operation_cancel = None
+                self._cancel_reason = None
+        duration_ms = max(0, round((self._clock() - started_at) * 1000))
+        self._log("failed", 0, reason, duration_ms)
 
     def _capture(self, stop_event, received_at) -> None:
         with self._lock:
             started_at = self._started_at if self._started_at is not None else self._clock()
             deadline = self._deadline if self._deadline is not None else started_at
-        accepted: list[Path] = []
-        published: list[Path] = []
+            wall_deadline = (
+                self._wall_deadline
+                if self._wall_deadline is not None
+                else monotonic()
+            )
+            operation_done = Event()
+            operation_cancel = Event()
+            self._operation_done = operation_done
+            self._operation_cancel = operation_cancel
+            self._cancel_reason = None
+            self._completion_reported = False
+            operation_thread = Thread(
+                target=self._capture_operation,
+                args=(
+                    stop_event, received_at, started_at, deadline, wall_deadline,
+                    operation_done, operation_cancel,
+                ),
+                name="gate-reolink-operation",
+                daemon=True,
+            )
+            self._operation_thread = operation_thread
+        operation_thread.start()
+
+        while True:
+            if stop_event.is_set():
+                self._cancel_active_operation("shutdown")
+                break
+            remaining = min(deadline - self._clock(), wall_deadline - monotonic())
+            if remaining <= 0:
+                self._cancel_active_operation("timeout")
+                break
+            if operation_done.wait(min(SAMPLER_POLL_SECONDS, remaining)):
+                return
+
+        try:
+            self._deliver_completion((), received_at)
+        except Exception:
+            pass
+        duration_ms = max(0, round((monotonic() - (
+            wall_deadline - self._config.timeout_seconds
+        )) * 1000))
+        reason = "shutdown" if stop_event.is_set() else "timeout"
+        self._log("failed", 0, reason, duration_ms)
+
+    def _capture_operation(self, stop_event, received_at, started_at: float,
+                           deadline: float, wall_deadline: float,
+                           operation_done: Event, operation_cancel: Event) -> None:
+        accepted = []
+        published = []
         token = None
         reason = None
         client = None
         prefix = None
-        directory_fd = None
         try:
             prefix = self._run_id()
-            directory_fd = self._open_output_directory(create=True)
+            if self._spool is None:
+                raise SnapshotFailure("io_error")
             client = self._client_factory(self._config)
-            token = client.login(self._remaining(deadline, stop_event))
+            token = client.login(self._remaining(
+                deadline, wall_deadline, stop_event, operation_cancel
+            ))
+            self._remaining(deadline, wall_deadline, stop_event, operation_cancel)
             for sequence in range(1, self._config.candidate_count + 1):
                 response = client.snapshot(
-                    token, sequence, self._remaining(deadline, stop_event)
+                    token, sequence, self._remaining(
+                        deadline, wall_deadline, stop_event, operation_cancel
+                    )
                 )
-                self._remaining(deadline, stop_event)
-                path = self._store_candidate(directory_fd, prefix, sequence, response)
+                self._remaining(
+                    deadline, wall_deadline, stop_event, operation_cancel
+                )
+                path = self._store_candidate(prefix, sequence, response)
+                self._remaining(
+                    deadline, wall_deadline, stop_event, operation_cancel
+                )
                 accepted.append(path)
         except SnapshotFailure as error:
             reason = error.reason
@@ -417,150 +716,159 @@ class ReolinkSnapshotSampler:
         except Exception:
             reason = "internal_error"
         finally:
-            if reason != "shutdown":
-                for path in accepted:
-                    try:
-                        self._add_candidate(path, received_at)
-                    except Exception:
-                        reason = reason or "collector_error"
-                        break
-                    published.append(path)
-            if token is not None and client is not None and not stop_event.is_set():
+            if token is not None and client is not None:
                 try:
-                    remaining = deadline - self._clock()
-                    if remaining > 0:
-                        client.logout(token, remaining)
+                    client.logout(token, self._remaining(
+                        deadline, wall_deadline, stop_event, operation_cancel
+                    ))
+                    self._remaining(
+                        deadline, wall_deadline, stop_event, operation_cancel
+                    )
+                except SnapshotFailure as error:
+                    if error.reason in {"timeout", "shutdown"}:
+                        reason = error.reason
                 except Exception:
                     pass
-            if prefix is not None and directory_fd is not None:
-                self._cleanup_prefix(
-                    prefix, keep=set(published), directory_fd=directory_fd,
-                )
-            if directory_fd is not None:
-                os.close(directory_fd)
+            completion_paths = (
+                () if reason in {"shutdown", "timeout"} else tuple(accepted)
+            )
+            try:
+                if completion_paths:
+                    self._remaining(
+                        deadline, wall_deadline, stop_event, operation_cancel
+                    )
+                delivered = self._deliver_completion(completion_paths, received_at)
+            except Exception:
+                delivered = False
+            if delivered:
+                published.extend(completion_paths)
+            elif delivered is False:
+                reason = reason or "collector_error"
+            for candidate in accepted:
+                if candidate not in published:
+                    candidate.close()
+            if prefix is not None:
+                self._cleanup_prefix(prefix, keep=set(published))
             with self._lock:
+                reported = self._completion_reported
+                if self._closed:
+                    self._close_resources_locked()
                 self._active = False
                 self._started_at = None
                 self._deadline = None
+                self._wall_deadline = None
+                self._operation_thread = None
+                self._operation_done = None
+                self._operation_cancel = None
+                self._cancel_reason = None
+                operation_done.set()
             duration_ms = max(0, round((self._clock() - started_at) * 1000))
             if reason is None and len(published) != self._config.candidate_count:
                 reason = "incomplete"
-            self._log(
-                "completed" if reason is None else "failed",
-                len(published), reason or "none", duration_ms,
-            )
+            if not reported:
+                self._log(
+                    "completed" if reason is None else "failed",
+                    len(published), reason or "none", duration_ms,
+                )
 
-    def _remaining(self, deadline: float, stop_event) -> float:
+    def _remaining(self, deadline: float, wall_deadline: float, stop_event,
+                   operation_cancel: Event) -> float:
         if stop_event.is_set():
             raise SnapshotFailure("shutdown")
-        remaining = deadline - self._clock()
+        if operation_cancel.is_set():
+            with self._lock:
+                reason = self._cancel_reason or "shutdown"
+            raise SnapshotFailure(reason)
+        remaining = min(deadline - self._clock(), wall_deadline - monotonic())
         if remaining <= 0:
             raise SnapshotFailure("timeout")
         return remaining
 
-    def _store_candidate(self, directory_fd: int, prefix: str, sequence: int,
-                         response: SnapshotResponse) -> Path:
+    def _cancel_active_operation(self, reason: str) -> None:
+        with self._lock:
+            if self._cancel_reason is None:
+                self._cancel_reason = reason
+            self._completion_reported = True
+            operation_cancel = self._operation_cancel
+        if operation_cancel is not None:
+            operation_cancel.set()
+
+    def _deliver_completion(self, paths: tuple, received_at) -> bool | None:
+        with self._lock:
+            if self._completion_delivered:
+                return None
+            self._completion_delivered = True
+        self._complete(paths, received_at)
+        return True
+
+    def _store_candidate(self, prefix: str, sequence: int,
+                         response: SnapshotResponse):
         if response.content_type.lower() != "image/jpeg":
             raise SnapshotFailure("invalid_content")
         if len(response.data) > self._config.max_response_bytes:
             raise SnapshotFailure("output_limit")
-        if not is_decodable_jpeg(response.data):
-            raise SnapshotFailure("invalid_jpeg")
-        final_name = f"{prefix}-{sequence:02d}.jpg"
-        temporary_name = f"{prefix}-{sequence:02d}.part"
-        final_path = self._config.output_directory / final_name
+        filename = f"{prefix}-{sequence:02d}.jpg"
+        candidate = None
+        if self._spool is None:
+            raise SnapshotFailure("disabled")
         try:
-            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-            file_descriptor = os.open(
-                temporary_name, flags, 0o600, dir_fd=directory_fd,
-            )
-            with os.fdopen(file_descriptor, "wb") as destination:
-                destination.write(response.data)
-            os.replace(
-                temporary_name, final_name,
-                src_dir_fd=directory_fd, dst_dir_fd=directory_fd,
-            )
+            candidate = self._spool.store(filename, response.data)
+            if not wait_until_readable(candidate, timeout=0, poll_interval=0):
+                raise SnapshotFailure("invalid_jpeg")
         except Exception:
-            for name in (temporary_name, final_name):
-                try:
-                    os.unlink(name, dir_fd=directory_fd)
-                except OSError:
-                    pass
+            if candidate is not None:
+                candidate.close()
+            self._spool.cleanup_prefix(prefix, keep=set())
             raise
-        return final_path
+        return candidate
 
     def close(self) -> None:
+        complete_queued = False
         with self._lock:
             self._closed = True
-            self._active = False
-        self._cleanup_all()
+            if self._operation_thread is not None:
+                if self._cancel_reason is None:
+                    self._cancel_reason = "shutdown"
+                if self._operation_cancel is not None:
+                    self._operation_cancel.set()
+                return
+            complete_queued = self._active
+        if complete_queued:
+            self._complete_queued_shutdown()
+        with self._lock:
+            self._close_resources_locked()
 
-    def _open_output_directory(self, *, create: bool) -> int:
-        output_directory = self._config.output_directory
-        if create:
-            output_directory.parent.mkdir(parents=True, exist_ok=True)
-        flags = (
-            os.O_RDONLY
-            | getattr(os, "O_DIRECTORY", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
-        parent_fd = os.open(output_directory.parent, flags)
-        try:
-            if create:
-                try:
-                    os.mkdir(output_directory.name, mode=0o700, dir_fd=parent_fd)
-                except FileExistsError:
-                    pass
-            directory_fd = os.open(output_directory.name, flags, dir_fd=parent_fd)
-        finally:
-            os.close(parent_fd)
-        if create:
-            os.fchmod(directory_fd, 0o700)
-        return directory_fd
-
-    def _cleanup_prefix(self, prefix: str, *, keep: set[Path],
-                        directory_fd: int | None = None) -> None:
-        close_directory = directory_fd is None
-        try:
-            if directory_fd is None:
-                directory_fd = self._open_output_directory(create=False)
-            keep_names = {path.name for path in keep}
-            for name in os.listdir(directory_fd):
-                if name.startswith(f"{prefix}-") and name not in keep_names:
-                    self._unlink_file_entry(directory_fd, name)
-        except FileNotFoundError:
+    def _close_resources_locked(self) -> None:
+        if self._resources_closed:
             return
+        try:
+            self._cleanup_all()
+        finally:
+            if self._spool is not None:
+                self._spool.close()
+            self._resources_closed = True
+
+    def _cleanup_prefix(self, prefix: str, *, keep: set[Path]) -> None:
+        if self._spool is None:
+            return
+        try:
+            self._spool.cleanup_prefix(prefix, keep=keep)
         except OSError:
             LOGGER.warning(
                 "gate_camera source=camera_ftp subtype=unverified "
                 "augmentation=reolink_snapshot outcome=cleanup_failed reason=io_error"
             )
-        finally:
-            if close_directory and directory_fd is not None:
-                os.close(directory_fd)
 
     def _cleanup_all(self) -> None:
-        directory_fd = None
-        try:
-            directory_fd = self._open_output_directory(create=False)
-            for name in os.listdir(directory_fd):
-                self._unlink_file_entry(directory_fd, name)
-        except FileNotFoundError:
+        if self._spool is None:
             return
+        try:
+            self._spool.cleanup_all()
         except OSError:
             LOGGER.warning(
                 "gate_camera source=camera_ftp subtype=unverified "
                 "augmentation=reolink_snapshot outcome=cleanup_failed reason=io_error"
             )
-        finally:
-            if directory_fd is not None:
-                os.close(directory_fd)
-
-    @staticmethod
-    def _unlink_file_entry(directory_fd: int, name: str) -> None:
-        entry = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
-        if stat.S_ISREG(entry.st_mode) or stat.S_ISLNK(entry.st_mode):
-            os.unlink(name, dir_fd=directory_fd)
 
     @staticmethod
     def _log(outcome: str, count: int, reason: str, duration_ms: int) -> None:

--- a/gate_controller/store.py
+++ b/gate_controller/store.py
@@ -1264,6 +1264,8 @@ def _telemetry_payload(telemetry: EventTelemetry) -> dict:
     }
     if "stage_timestamps" in raw:
         payload["stage_timestamps"] = dict(raw["stage_timestamps"])
+    if "augmentation" in raw:
+        payload["augmentation"] = dict(raw["augmentation"])
     return payload
 
 
@@ -1372,6 +1374,15 @@ def _decode_telemetry_payload(encoded: object) -> dict:
         or any(not isinstance(value, str) for value in stage_timestamps.values())
     ):
         raise _MalformedTelemetry("telemetry stage timestamps are invalid")
+    augmentation = telemetry.get("augmentation")
+    if augmentation is not None and (
+        not isinstance(augmentation, dict)
+        or not isinstance(augmentation.get("outcome"), str)
+        or not isinstance(augmentation.get("reason"), str)
+        or not isinstance(augmentation.get("candidate_count"), int)
+        or not isinstance(augmentation.get("duration_ms"), int)
+    ):
+        raise _MalformedTelemetry("telemetry augmentation is invalid")
     return telemetry
 
 

--- a/gate_controller/telemetry.py
+++ b/gate_controller/telemetry.py
@@ -128,6 +128,29 @@ class OcrAttemptTelemetry:
 
 
 @dataclass(frozen=True)
+class AugmentationTelemetry:
+    outcome: str
+    reason: str
+    candidate_count: int
+    duration_ms: float
+    correlation: str | None = None
+
+    def to_wire(self) -> dict[str, object]:
+        payload = {
+            "outcome": _token(self.outcome),
+            "reason": _token(self.reason),
+            "candidate_count": _rounded_int(
+                self.candidate_count, 0, MAX_ITEMS, 0,
+            ),
+            "duration_ms": _duration(self.duration_ms) or 0,
+        }
+        correlation = _optional_string(self.correlation)
+        if correlation is not None:
+            payload["correlation"] = correlation
+        return payload
+
+
+@dataclass(frozen=True)
 class StageTimestamps:
     filesystem_ingress_at: datetime | None = None
     burst_processing_started_at: datetime | None = None
@@ -204,6 +227,7 @@ class EventTelemetry:
     outbox_attempt: int
     delivery_state: str
     stage_timestamps: StageTimestamps = field(default_factory=StageTimestamps)
+    augmentation: AugmentationTelemetry | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "trace_id", _trace_id(self.trace_id))
@@ -252,6 +276,8 @@ class EventTelemetry:
         timestamps = self.stage_timestamps.to_wire()
         if timestamps:
             payload["stage_timestamps"] = timestamps
+        if self.augmentation is not None:
+            payload["augmentation"] = self.augmentation.to_wire()
         return payload
 
 
@@ -290,6 +316,7 @@ class ProcessingTrace:
         self._actuation_claim = "not_requested"
         self._actuation_attempted = False
         self._relay_outcome = "not_attempted"
+        self._augmentation: AugmentationTelemetry | None = None
         self._finished_telemetry: EventTelemetry | None = None
 
     def seed_upstream(
@@ -324,6 +351,9 @@ class ProcessingTrace:
     def mark_burst(self) -> None:
         if self._burst is None:
             self._burst = self._monotonic_clock()
+
+    def set_augmentation(self, augmentation: AugmentationTelemetry | None) -> None:
+        self._augmentation = augmentation
 
     def add_frame(self, frame: FrameTelemetry) -> None:
         if len(self._frames) < MAX_ITEMS:
@@ -440,6 +470,7 @@ class ProcessingTrace:
                 relay_finished_at=self._wall_at(self._relay_finished),
                 processing_finished_at=self._wall_at(self._finished),
             ),
+            augmentation=self._augmentation,
         )
         return self._finished_telemetry
 

--- a/gate_controller/worker.py
+++ b/gate_controller/worker.py
@@ -1,10 +1,12 @@
 import logging
 import os
+from collections import deque
+from dataclasses import dataclass, field
 from pathlib import Path
-from queue import Empty, Full, Queue
+from queue import Empty, Queue
 import signal
 from datetime import datetime, timezone
-from threading import Event, Lock, Thread
+from threading import Condition, Event, Lock, Thread
 from time import monotonic, sleep, time
 
 from watchdog.events import FileSystemEventHandler
@@ -21,6 +23,7 @@ DEFAULT_MAX_CANDIDATE_BYTES = 8 * 1024 * 1024
 MAX_BURST_CANDIDATES = 16
 MAX_CANDIDATE_BYTES = 16 * 1024 * 1024
 MAX_STARTUP_ENTRIES = 128
+MAX_FINAL_OCR_CANDIDATES = 3
 
 
 LOGGER = logging.getLogger(__name__)
@@ -31,31 +34,138 @@ class WorkerFailure(RuntimeError):
 
 
 class BoundedBurstQueue:
-    """A one-consumer queue that keeps the freshest pending camera work."""
+    """Keep fresh FTP work in a lane that snapshots cannot displace."""
 
-    def __init__(self, max_pending: int = 2):
-        self._queue = Queue(maxsize=max_pending)
+    def __init__(self, max_pending: int = 2, on_discard=None):
+        self._max_pending = max_pending
+        self._on_discard = on_discard
+        self._primary = deque()
+        self._augmentation = deque()
+        self._augmentation_reservations = 0
+        self._stopping = False
+        self._condition = Condition()
 
     def put(self, item):
-        dropped = None
-        if self._queue.full():
-            try:
-                dropped = self._queue.get_nowait()
-            except Empty:
-                pass
-        self._queue.put(item)
+        if item is None:
+            self.stop()
+            return None
+        discard = False
+        with self._condition:
+            if self._stopping:
+                discard = True
+                dropped = None
+            else:
+                dropped = None
+                if len(self._primary) >= self._max_pending:
+                    dropped = self._primary.popleft()
+                self._primary.append(item)
+                self._condition.notify()
+        if discard:
+            self._discard((item,))
         return dropped
 
-    def get(self):
-        return self._queue.get()
-
-    def try_put(self, item) -> bool:
-        """Admit optional work only when it cannot displace queued work."""
-        try:
-            self._queue.put_nowait(item)
+    def reserve_augmentation(self) -> bool:
+        with self._condition:
+            if self._stopping or self._augmentation_reservations >= self._max_pending:
+                return False
+            self._augmentation_reservations += 1
             return True
-        except Full:
-            return False
+
+    def cancel_augmentation_reservation(self) -> None:
+        with self._condition:
+            if self._augmentation_reservations > len(self._augmentation):
+                self._augmentation_reservations -= 1
+
+    def put_augmentation(self, item):
+        discard = False
+        with self._condition:
+            if self._stopping:
+                discard = True
+            elif self._augmentation_reservations <= len(self._augmentation):
+                raise RuntimeError("augmentation queue slot was not reserved")
+            else:
+                self._augmentation.append(item)
+                self._condition.notify()
+        if discard:
+            self._discard((item,))
+        return None
+
+    def stop(self) -> None:
+        with self._condition:
+            if self._stopping:
+                return
+            self._stopping = True
+            discarded = tuple(self._primary) + tuple(self._augmentation)
+            self._primary.clear()
+            self._augmentation.clear()
+            self._augmentation_reservations = 0
+            self._condition.notify_all()
+        self._discard(discarded)
+
+    def get(self):
+        with self._condition:
+            while (
+                not self._primary
+                and not self._augmentation
+                and not self._stopping
+            ):
+                self._condition.wait()
+            if self._stopping:
+                return None
+            if self._primary:
+                return self._primary.popleft()
+            if self._augmentation:
+                self._augmentation_reservations -= 1
+                return self._augmentation.popleft()
+            return None
+
+    def _discard(self, items) -> None:
+        if self._on_discard is None:
+            return
+        for item in items:
+            try:
+                self._on_discard(self, item)
+            except Exception:
+                LOGGER.exception("gate_burst_shutdown_cleanup_failed")
+
+
+@dataclass
+class ProgressiveTrigger:
+    received_at: datetime
+    release: object = lambda: None
+    primary_item: tuple | None = None
+    snapshots: tuple[Path, ...] | None = None
+    initial_result: object | None = None
+    failed: bool = False
+    finalized: bool = False
+    finalizing: bool = False
+    augmentation_submitted: bool = False
+    abandoned: bool = False
+    augmentation_started_at: float | None = None
+    augmentation_reason: str | None = None
+    terminalizer: object | None = None
+    _lock: Lock = field(default_factory=Lock, repr=False)
+    _released: bool = False
+
+    def release_once(self) -> None:
+        with self._lock:
+            if self._released:
+                return
+            self._released = True
+        self.release()
+
+
+@dataclass(frozen=True)
+class BurstWork:
+    kind: str
+    item: tuple
+    trigger: ProgressiveTrigger
+
+
+@dataclass(frozen=True)
+class CollectedBurst:
+    item: tuple
+    context: object
 
 
 class BurstCollector:
@@ -64,7 +174,7 @@ class BurstCollector:
                  include_decision_started_at: bool = False,
                  include_processing_started_at: bool = False,
                  max_candidates: int = DEFAULT_MAX_BURST_CANDIDATES,
-                 wall_clock=None):
+                 wall_clock=None, on_abandoned=None):
         if not 1 <= max_candidates <= MAX_BURST_CANDIDATES:
             raise ValueError("max_candidates exceeds the safe range")
         self._emit = emit
@@ -77,14 +187,17 @@ class BurstCollector:
         self._include_decision_started_at = include_decision_started_at
         self._include_processing_started_at = include_processing_started_at
         self._max_candidates = max_candidates
+        self._on_abandoned = on_abandoned
         self._pending: list[Path] = []
         self._received_at: datetime | None = None
         self._first_seen: float | None = None
         self._deadline: float | None = None
+        self._context = None
         self._lock = Lock()
 
     def add(self, path: Path, received_at: datetime | None = None) -> bool:
-        path = Path(path)
+        if not getattr(path, "_descriptor_anchored", False):
+            path = Path(path)
         dropped = None
         with self._lock:
             first_candidate = not self._pending
@@ -103,6 +216,13 @@ class BurstCollector:
             _remove_upload(dropped)
         return first_candidate
 
+    def bind_context(self, context) -> bool:
+        with self._lock:
+            if not self._pending or self._context is not None:
+                return False
+            self._context = context
+            return True
+
     def flush_due(self) -> bool:
         with self._lock:
             decision_started_at = self._clock()
@@ -112,14 +232,18 @@ class BurstCollector:
             pending = tuple(self._pending)
             received_at = self._received_at
             first_seen = self._first_seen
+            context = self._context
             self._pending = []
             self._received_at = None
             self._first_seen = None
             self._deadline = None
+            self._context = None
         ranked = tuple(self._ranker(pending))
         ranked_paths = set(ranked)
         _remove_uploads(path for path in pending if path not in ranked_paths)
         if not ranked:
+            if context is not None and self._on_abandoned is not None:
+                self._on_abandoned(context)
             return False
         wait_ms = (
             max(0, round((decision_started_at - first_seen) * 1_000))
@@ -139,7 +263,10 @@ class BurstCollector:
             details.append(decision_started_at)
         if self._include_processing_started_at:
             details.append(processing_started_at)
-        self._emit(tuple(details) if len(details) > 1 else ranked)
+        item = tuple(details) if len(details) > 1 else ranked
+        self._emit(
+            CollectedBurst(item, context) if context is not None else item
+        )
         return True
 
 
@@ -245,7 +372,10 @@ class CompletedImageHandler(FileSystemEventHandler):
                 with self._lock:
                     self._retry_at.pop(path, None)
                 if first_candidate:
-                    self._request_augmentation(received_at)
+                    context = self._request_augmentation(received_at)
+                    bind_context = getattr(self._collector, "bind_context", None)
+                    if context is not None and callable(bind_context):
+                        bind_context(context)
                 completed += 1
             else:
                 with self._lock:
@@ -254,25 +384,26 @@ class CompletedImageHandler(FileSystemEventHandler):
                                                 attempts + 1, received_at)
         return completed
 
-    def _request_augmentation(self, received_at: datetime) -> None:
+    def _request_augmentation(self, received_at: datetime):
         request = "disabled"
+        context = None
         if self._on_first_completed is not None:
             try:
-                request = (
-                    "skipped"
-                    if self._on_first_completed(received_at) is False
-                    else "accepted"
-                )
+                result = self._on_first_completed(received_at)
+                request = "skipped" if result is False else "accepted"
+                if result is not None and result is not False and result is not True:
+                    context = result
             except Exception:
                 LOGGER.warning(
                     "gate_camera source=camera_ftp subtype=unverified "
                     "augmentation_request=failed reason=request_error"
                 )
-                return
+                return None
         LOGGER.info(
             "gate_camera source=camera_ftp subtype=unverified augmentation_request=%s",
             request,
         )
+        return context
 
     def _too_large(self, path: Path) -> bool:
         try:
@@ -374,30 +505,34 @@ def run_worker(directory: Path, emit, quiet_window: float = 0.5,
                max_candidate_bytes: int = DEFAULT_MAX_CANDIDATE_BYTES,
                on_timed_skipped=None, snapshot_sampling=None) -> None:
     """Watch completed JPEG uploads and process ranked bursts without blocking collection."""
-    bursts = BoundedBurstQueue(max_pending_bursts)
+    bursts = BoundedBurstQueue(
+        max_pending_bursts,
+        on_discard=lambda queue, item: _discard_burst_work(item, queue),
+    )
 
     def report_dropped(item, reason):
+        if isinstance(item, BurstWork):
+            item = item.item
         paths, received_at, *timing = item
         if on_timed_skipped is not None and timing:
             on_timed_skipped(paths, reason, received_at, *timing)
         elif on_skipped is not None:
             on_skipped(paths, reason, received_at)
 
-    def enqueue_primary(item):
-        dropped = bursts.put(item)
+    def enqueue(item):
+        work = (
+            BurstWork("primary", item.item, item.context)
+            if isinstance(item, CollectedBurst) else item
+        )
+        dropped = bursts.put(work)
         if dropped is not None:
             try:
                 report_dropped(dropped, "queue_coalesced")
             finally:
-                _remove_uploads(dropped[0])
-
-    def enqueue_augmentation(item):
-        if bursts.try_put(item):
-            return
-        try:
-            report_dropped(item, "augmentation_queue_full")
-        finally:
-            _remove_uploads(item[0])
+                dropped_item = dropped.item if isinstance(dropped, BurstWork) else dropped
+                _remove_uploads(dropped_item[0])
+                if isinstance(dropped, BurstWork):
+                    _abandon_progressive_trigger(dropped.trigger, bursts)
 
     collector_options = {
         "quiet_window": quiet_window,
@@ -406,29 +541,67 @@ def run_worker(directory: Path, emit, quiet_window: float = 0.5,
         "include_decision_started_at": True,
         "include_processing_started_at": True,
         "max_candidates": max_burst_candidates,
+        "on_abandoned": lambda trigger: _abandon_progressive_trigger(
+            trigger, bursts
+        ),
     }
-    collector = BurstCollector(enqueue_primary, **collector_options)
+    collector = BurstCollector(enqueue, **collector_options)
     sampler = None
-    augmentation_collector = None
+    progressive_triggers = {}
+    progressive_triggers_lock = Lock()
     sampling_enabled = bool(snapshot_sampling is not None and snapshot_sampling.enabled)
-    if snapshot_sampling is not None:
-        if sampling_enabled:
-            augmentation_collector = BurstCollector(
-                enqueue_augmentation, **collector_options,
+
+    def release_trigger(key, trigger):
+        with progressive_triggers_lock:
+            if progressive_triggers.get(key) is trigger:
+                progressive_triggers.pop(key, None)
+
+    def complete_augmentation(paths, received_at):
+        paths = tuple(paths)
+        key = id(received_at)
+        with progressive_triggers_lock:
+            trigger = progressive_triggers.get(key)
+        if trigger is None:
+            _remove_uploads(paths)
+            return
+        with trigger._lock:
+            if trigger.abandoned:
+                _remove_uploads(paths)
+                return
+            trigger.snapshots = paths
+            trigger.augmentation_submitted = True
+            work = BurstWork(
+                "augmentation", (paths, trigger.received_at), trigger
             )
-            add_snapshot_candidate = augmentation_collector.add
-        else:
-            def add_snapshot_candidate(*_):
-                """Discard candidates while retaining startup cleanup behavior."""
-                return None
-        sampler = ReolinkSnapshotSampler(snapshot_sampling, add_snapshot_candidate)
+        bursts.put_augmentation(work)
+
+    if snapshot_sampling is not None:
+        sampler = ReolinkSnapshotSampler(snapshot_sampling, complete_augmentation)
+
+    def request_augmentation(received_at):
+        if sampler is None or not bursts.reserve_augmentation():
+            return False
+        key = id(received_at)
+        trigger = ProgressiveTrigger(
+            received_at, augmentation_started_at=monotonic(),
+        )
+        trigger.release = lambda: release_trigger(key, trigger)
+        with progressive_triggers_lock:
+            progressive_triggers[key] = trigger
+        if sampler.request(received_at):
+            return trigger
+        with progressive_triggers_lock:
+            progressive_triggers.pop(key, None)
+        bursts.cancel_augmentation_reservation()
+        return False
+
     handler = CompletedImageHandler(
         collector,
         on_rejected=(lambda path, reason: on_skipped((path,), reason, None)) if on_skipped else None,
         max_candidate_bytes=max_candidate_bytes,
         max_pending_candidates=max_burst_candidates,
-        on_first_completed=sampler.request if sampling_enabled else None,
-        ignored_roots=(sampler.output_directory,) if sampler is not None else (),
+        on_first_completed=request_augmentation if sampling_enabled else None,
+        ignored_roots=(sampler.output_directory,) if sampling_enabled else (),
     )
     observer = Observer()
     observer.schedule(handler, str(directory), recursive=True)
@@ -436,7 +609,10 @@ def run_worker(directory: Path, emit, quiet_window: float = 0.5,
     failures = Queue()
     processing_thread = Thread(
         target=_supervise_worker,
-        args=("GateBurstProcessor", _process_bursts, (bursts, emit, on_error),
+        args=("GateBurstProcessor", _process_bursts, (
+              bursts, emit, on_error,
+              lambda paths: rank_images(paths, max_bytes=max_candidate_bytes),
+        ),
               stop_event, failures),
         daemon=True, name="GateBurstProcessor",
     )
@@ -492,13 +668,12 @@ def run_worker(directory: Path, emit, quiet_window: float = 0.5,
                 startup_reconciliation_pending = startup_reconciler.run_batch()
             handler.retry_pending()
             collector.flush_due()
-            if augmentation_collector is not None:
-                augmentation_collector.flush_due()
             sleep(poll_interval)
     except KeyboardInterrupt:
         pass
     finally:
         stop_event.set()
+        bursts.put(None)
         try:
             if shutdown is not None:
                 shutdown()
@@ -509,44 +684,14 @@ def run_worker(directory: Path, emit, quiet_window: float = 0.5,
                 if observer_started:
                     observer.stop()
                     observer.join()
-                sampling_finished = not sampling_started
                 if sampling_started:
                     sampling_thread.join(
                         timeout=MAX_REOLINK_SNAPSHOT_TIMEOUT_SECONDS + 0.5
                     )
-                    is_alive = getattr(sampling_thread, "is_alive", None)
-                    sampling_finished = not callable(is_alive) or not is_alive()
-                processing_finished = not processing_started
-                if processing_started:
-                    dropped = bursts.put(None)
-                    if dropped is not None:
-                        try:
-                            report_dropped(dropped, "service_stopping")
-                        finally:
-                            _remove_uploads(dropped[0])
-                    processing_thread.join(timeout=5)
-                    is_alive = getattr(processing_thread, "is_alive", None)
-                    processing_finished = not callable(is_alive) or not is_alive()
-                if sampler is not None and sampling_finished and processing_finished:
+                if sampler is not None:
                     sampler.close()
-                elif sampler is not None:
-                    LOGGER.warning(
-                        "gate_camera source=camera_ftp subtype=unverified "
-                        "augmentation=reolink_snapshot outcome=cleanup_deferred "
-                        "reason=worker_active"
-                    )
-
-                    def close_sampler_after_workers_finish():
-                        if sampling_started:
-                            sampling_thread.join()
-                        if processing_started:
-                            processing_thread.join()
-                        sampler.close()
-
-                    Thread(
-                        target=close_sampler_after_workers_finish,
-                        daemon=True, name="ReolinkSnapshotCleanup",
-                    ).start()
+                if processing_started:
+                    processing_thread.join(timeout=5)
                 for thread in started_background_threads:
                     thread.join(timeout=1)
             finally:
@@ -561,11 +706,15 @@ def run_worker(directory: Path, emit, quiet_window: float = 0.5,
     raise WorkerFailure(f"critical worker {name} failed: {error}") from error
 
 
-def _process_bursts(bursts, emit, on_error=None) -> None:
+def _process_bursts(bursts, emit, on_error=None, ranker=None) -> None:
+    ranker = ranker or rank_images
     while True:
         item = bursts.get()
         if item is None:
             return
+        if isinstance(item, BurstWork):
+            _process_progressive_work(item, emit, on_error, bursts, ranker)
+            continue
         paths, received_at, *timing = item
         try:
             emit(paths, received_at, *timing)
@@ -574,6 +723,182 @@ def _process_bursts(bursts, emit, on_error=None) -> None:
                 on_error(paths, error, received_at)
         finally:
             _remove_uploads(paths)
+
+
+def _process_progressive_work(work: BurstWork, emit, on_error, bursts, ranker) -> None:
+    trigger = work.trigger
+    paths, received_at, *timing = work.item
+    paths = tuple(paths)
+    if work.kind == "augmentation":
+        with trigger._lock:
+            already_finalized = trigger.finalized
+            trigger.snapshots = paths
+            waiting_for_primary = (
+                trigger.initial_result is None and not trigger.failed
+            )
+        if already_finalized:
+            _cleanup_progressive_trigger(trigger, paths)
+            return
+        if waiting_for_primary:
+            return
+        _finalize_progressive_trigger(trigger, emit, on_error, ranker)
+        return
+
+    with trigger._lock:
+        trigger.primary_item = (paths, received_at, *timing)
+        trigger.terminalizer = lambda: _finalize_progressive_trigger(
+            trigger, emit, on_error, ranker,
+        )
+    try:
+        result = emit(paths, received_at, *timing, final=False)
+    except Exception as error:
+        if on_error is not None:
+            on_error(paths, error, received_at)
+        _remove_uploads(paths)
+        _abandon_progressive_trigger(trigger, bursts)
+        return
+    with trigger._lock:
+        trigger.initial_result = result
+        snapshots = trigger.snapshots
+        abandoned = trigger.abandoned
+    if getattr(result, "terminal", True):
+        _remove_uploads(paths)
+        _abandon_progressive_trigger(trigger, bursts)
+        return
+    if abandoned:
+        _finalize_progressive_trigger(trigger, emit, on_error, ranker)
+        return
+    if snapshots is not None:
+        _finalize_progressive_trigger(trigger, emit, on_error, ranker)
+
+
+def _finalize_progressive_trigger(trigger: ProgressiveTrigger, emit, on_error, ranker) -> None:
+    with trigger._lock:
+        if trigger.finalized or trigger.finalizing:
+            return
+        snapshots = trigger.snapshots or ()
+        primary_item = trigger.primary_item
+        failed = trigger.failed
+        result = trigger.initial_result
+        if primary_item is None or result is None:
+            if not failed:
+                return
+            trigger.finalizing = True
+            cleanup_paths = tuple(snapshots)
+            primary_item = None
+        else:
+            trigger.finalizing = True
+            cleanup_paths = tuple(primary_item[0]) + tuple(snapshots)
+        augmentation_started_at = trigger.augmentation_started_at
+        augmentation_reason = trigger.augmentation_reason
+    try:
+        if primary_item is None:
+            return
+        primary_paths, received_at, *timing = primary_item
+        if getattr(result, "terminal", True):
+            return
+        combined = tuple(primary_paths) + tuple(snapshots)
+        augmentation_failed = failed or not snapshots
+        selected = tuple(primary_paths)
+        if not augmentation_failed:
+            try:
+                selected = tuple(ranker(combined))[:MAX_FINAL_OCR_CANDIDATES]
+            except Exception as error:
+                _report_processing_error(on_error, combined, error, received_at)
+                augmentation_failed = True
+                augmentation_reason = "selection_error"
+            else:
+                augmentation_failed = not selected
+        options = {
+            "idempotency_key": result.idempotency_key,
+            "final": True,
+        }
+        if augmentation_failed:
+            selected = tuple(primary_paths)
+            options["provisional_result"] = result
+            options["augmentation"] = {
+                "outcome": "failed",
+                "reason": augmentation_reason or (
+                    "empty" if not snapshots else "selection_empty"
+                ),
+                "candidate_count": len(snapshots),
+                "duration_ms": _augmentation_duration_ms(augmentation_started_at),
+            }
+        else:
+            options["augmentation"] = {
+                "outcome": "completed",
+                "reason": "completed",
+                "candidate_count": len(snapshots),
+                "duration_ms": _augmentation_duration_ms(augmentation_started_at),
+                "correlation": result.idempotency_key,
+            }
+        try:
+            emit(selected, received_at, *timing, **options)
+        except Exception as error:
+            _report_processing_error(on_error, combined, error, received_at)
+    finally:
+        _cleanup_progressive_trigger(trigger, cleanup_paths)
+        with trigger._lock:
+            trigger.finalizing = False
+            trigger.finalized = True
+
+
+def _abandon_progressive_trigger(
+    trigger: ProgressiveTrigger, bursts: BoundedBurstQueue, reason: str = "abandoned",
+) -> None:
+    with trigger._lock:
+        if trigger.abandoned:
+            return
+        trigger.abandoned = True
+        trigger.failed = True
+        trigger.augmentation_reason = reason
+        snapshots = trigger.snapshots or ()
+        cancel_reservation = not trigger.augmentation_submitted
+        result = trigger.initial_result
+        terminalizer = trigger.terminalizer
+        primary_item = trigger.primary_item
+    if cancel_reservation:
+        bursts.cancel_augmentation_reservation()
+    if result is not None and not getattr(result, "terminal", True) and terminalizer:
+        terminalizer()
+        return
+    primary_paths = primary_item[0] if primary_item is not None else ()
+    _cleanup_progressive_trigger(trigger, tuple(primary_paths) + tuple(snapshots))
+
+
+def _discard_burst_work(item, bursts: BoundedBurstQueue) -> None:
+    if isinstance(item, BurstWork):
+        _abandon_progressive_trigger(item.trigger, bursts, reason="shutdown")
+        _remove_uploads(item.item[0])
+        return
+    _remove_uploads(item[0])
+
+
+def _augmentation_duration_ms(started_at: float | None) -> int:
+    if started_at is None:
+        return 0
+    return max(0, round((monotonic() - started_at) * 1_000))
+
+
+def _report_processing_error(on_error, paths, error, received_at) -> None:
+    if on_error is None:
+        return
+    try:
+        on_error(paths, error, received_at)
+    except Exception:
+        LOGGER.exception("gate_burst_error_handler_failed")
+
+
+def _cleanup_progressive_trigger(trigger: ProgressiveTrigger, paths) -> None:
+    try:
+        _remove_uploads(paths)
+    except Exception:
+        LOGGER.exception("gate_burst_cleanup_failed")
+    finally:
+        try:
+            trigger.release_once()
+        except Exception:
+            LOGGER.exception("gate_burst_release_failed")
 
 
 def _supervise_worker(name, target, args, stop_event, failures) -> None:
@@ -608,6 +933,9 @@ def _remove_uploads(paths) -> None:
 
 def _remove_upload(path: Path) -> None:
     try:
-        Path(path).unlink(missing_ok=True)
+        if getattr(path, "_descriptor_anchored", False):
+            path.unlink(missing_ok=True)
+        else:
+            Path(path).unlink(missing_ok=True)
     except OSError as error:
         LOGGER.warning("camera_upload_cleanup_failed path=%s error=%s", path, error)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -19,7 +19,7 @@ from gate_controller.relay import RelayController
 from gate_controller.store import LocalStore
 from gate_controller.authorisation import AuthorisedPlateCache
 from gate_controller.images import rank_images
-from gate_controller.telemetry import ProcessingTrace
+from gate_controller.telemetry import FrameTelemetry, ProcessingTrace
 
 
 class StaticRecognizer:
@@ -887,6 +887,103 @@ class GateProcessorTests(unittest.TestCase):
                 "outcome": "denied",
                 "reason": reason,
             })
+
+    def test_empty_augmentation_terminalizes_the_provisional_recognition_trace(self):
+        received_at = datetime(2026, 8, 20, 11, 15, tzinfo=timezone.utc)
+        relay_calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            frame = Path(directory) / "ftp.jpg"
+            frame.write_bytes(b"ftp-candidate")
+            store = LocalStore(Path(directory) / "gate.db")
+            processor = self._processor(
+                store,
+                RecordingRelay(relay_calls),
+                StaticRecognizer(PlateObservation("NOPE", 0.87)),
+                clock=lambda: received_at,
+            )
+            quality = FrameTelemetry(
+                sequence=0,
+                digest="0" * 64,
+                width=16,
+                height=8,
+                sharpness=0.4,
+                brightness=0.5,
+                darkness=0.1,
+                highlight_clipping=0.0,
+            )
+            with patch(
+                "gate_controller.processor.measure_frame_quality",
+                return_value=quality,
+            ):
+                provisional = processor.process(
+                    (frame,), received_at=received_at, final=False,
+                )
+                terminal = processor.process(
+                    (frame,),
+                    received_at=received_at,
+                    idempotency_key=provisional.idempotency_key,
+                    provisional_result=provisional,
+                    augmentation={
+                        "outcome": "failed",
+                        "reason": "empty",
+                        "candidate_count": 0,
+                        "duration_ms": 42,
+                    },
+                )
+            persisted = store.event_telemetry(terminal.event_id)
+
+        self.assertFalse(provisional.terminal)
+        self.assertTrue(terminal.terminal)
+        self.assertEqual(terminal.reason, provisional.reason)
+        self.assertEqual(terminal.decision, provisional.decision)
+        self.assertEqual(relay_calls, [])
+        self.assertEqual(persisted["frames"], provisional.telemetry.to_wire()["frames"])
+        self.assertEqual(
+            persisted["ocr_attempts"], provisional.telemetry.to_wire()["ocr_attempts"],
+        )
+        self.assertEqual(
+            persisted["stage_durations"],
+            provisional.telemetry.to_wire()["stage_durations"],
+        )
+        self.assertEqual(persisted["decision"], provisional.telemetry.to_wire()["decision"])
+        self.assertEqual(persisted["augmentation"], {
+            "outcome": "failed",
+            "reason": "empty",
+            "candidate_count": 0,
+            "duration_ms": 42,
+        })
+
+    def test_successful_augmentation_is_persisted_with_correlation(self):
+        received_at = datetime(2026, 8, 20, 12, 45, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "snapshot.jpg")
+            store = LocalStore(Path(directory) / "gate.db")
+            result = self._processor(
+                store,
+                RecordingRelay([]),
+                StaticRecognizer(PlateObservation(None, 0.0)),
+                clock=lambda: received_at,
+            ).process(
+                (frame,),
+                received_at=received_at,
+                augmentation={
+                    "outcome": "completed",
+                    "reason": "completed",
+                    "candidate_count": 2,
+                    "duration_ms": 37,
+                    "correlation": "ftp-trigger",
+                },
+            )
+            persisted = store.event_telemetry(result.event_id)
+
+        self.assertFalse(result.opened)
+        self.assertEqual(persisted["augmentation"], {
+            "outcome": "completed",
+            "reason": "completed",
+            "candidate_count": 2,
+            "duration_ms": 37,
+            "correlation": "ftp-trigger",
+        })
 
     def test_direct_skip_trace_factory_failure_still_records_the_event(self):
         def fail_factory(**kwargs):
@@ -1999,6 +2096,109 @@ class GateProcessorTests(unittest.TestCase):
 
             self.assertTrue(first.opened)
             self.assertTrue(second.opened)
+
+    def test_progressive_snapshot_reuses_the_ftp_trigger_single_actuation_claim(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ftp = self._jpeg(directory, "ftp.jpg", 32)
+            snapshot = self._jpeg(directory, "snapshot.jpg", 224)
+            calls = []
+            now = [datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc)]
+            store = LocalStore(root / "gate.db")
+            processor = self._processor(
+                store,
+                RecordingRelay(calls),
+                StaticRecognizer(PlateObservation("12D3456", 0.95)),
+                cooldown=timedelta(seconds=0),
+                max_image_age=timedelta(minutes=5),
+                clock=lambda: now[0],
+                outbox=object(),
+            )
+
+            initial = processor.process((ftp,), final=False)
+            now[0] += timedelta(minutes=1)
+            augmented = processor.process(
+                (ftp, snapshot),
+                idempotency_key=initial.idempotency_key,
+                final=True,
+            )
+
+            self.assertTrue(initial.opened)
+            self.assertTrue(initial.terminal)
+            self.assertEqual(augmented.reason, "duplicate_event")
+            self.assertEqual(initial.event_id, store.event_id(initial.idempotency_key))
+            self.assertEqual(store.pending_outbox_count(), 1)
+            self.assertEqual(calls, ["relay"])
+
+    def test_improvable_ftp_denial_is_provisional_until_snapshots_finalize_its_key(self):
+        class PathRecognizer:
+            def recognise(self, path):
+                if Path(path).name == "snapshot.jpg":
+                    return PlateObservation("12D3456", 0.95)
+                return PlateObservation(None, 0.0)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ftp = self._jpeg(directory, "ftp.jpg", 32)
+            snapshot = self._jpeg(directory, "snapshot.jpg", 224)
+            calls = []
+            store = LocalStore(root / "gate.db")
+            processor = self._processor(
+                store,
+                RecordingRelay(calls),
+                PathRecognizer(),
+                cooldown=timedelta(seconds=0),
+                max_image_age=timedelta(minutes=5),
+            )
+
+            initial = processor.process((ftp,), final=False)
+
+            self.assertEqual(initial.reason, "no_match")
+            self.assertFalse(initial.terminal)
+            self.assertIsNone(initial.event_id)
+            self.assertFalse(store.event_exists(initial.idempotency_key))
+            self.assertEqual(calls, [])
+
+            augmented = processor.process(
+                (ftp, snapshot),
+                idempotency_key=initial.idempotency_key,
+                final=True,
+            )
+
+            self.assertTrue(augmented.opened)
+            self.assertTrue(augmented.terminal)
+            self.assertEqual(store.event_id(initial.idempotency_key), augmented.event_id)
+            self.assertEqual(calls, ["relay"])
+
+    def test_empty_augmentation_terminally_persists_original_without_repeating_ocr(self):
+        class CountingRecognizer:
+            def __init__(self):
+                self.calls = 0
+
+            def recognise(self, path):
+                self.calls += 1
+                return PlateObservation(None, 0.0)
+
+        with tempfile.TemporaryDirectory() as directory:
+            image = self._jpeg(directory, "ftp.jpg")
+            recognizer = CountingRecognizer()
+            store = LocalStore(Path(directory) / "gate.db")
+            processor = self._processor(
+                store, RecordingRelay([]), recognizer,
+            )
+            initial = processor.process((image,), final=False)
+
+            finalized = processor.process(
+                (image,), idempotency_key=initial.idempotency_key, final=True,
+                provisional_result=initial,
+            )
+
+            self.assertEqual(recognizer.calls, 1)
+            self.assertTrue(finalized.terminal)
+            self.assertEqual(finalized.reason, "no_match")
+            self.assertEqual(
+                finalized.event_id, store.event_id(initial.idempotency_key)
+            )
 
     def test_reordered_frames_with_the_same_content_are_a_duplicate(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_reolink_snapshots.py
+++ b/tests/test_reolink_snapshots.py
@@ -1,9 +1,11 @@
 import io
 import tempfile
 import unittest
-from datetime import datetime, timezone
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Event
+from time import monotonic, sleep
 from unittest.mock import patch
 from urllib.error import HTTPError
 
@@ -17,9 +19,18 @@ from gate_controller.reolink_snapshots import (
     RejectRedirects,
     SnapshotFailure,
     SnapshotResponse,
+    _SnapshotSpool,
     load_reolink_snapshot_config,
 )
-from gate_controller.worker import BurstCollector, CompletedImageHandler, StartupReconciler
+from gate_controller.images import wait_until_readable
+from gate_controller.models import PlateObservation, RelayResult
+from gate_controller.outbox import OutboxWorker
+from gate_controller.processor import GateProcessor
+from gate_controller.store import LocalStore
+from gate_controller.worker import (
+    BoundedBurstQueue, BurstCollector, CompletedImageHandler, StartupReconciler,
+    _remove_upload, run_worker,
+)
 
 
 def jpeg_bytes(color=(20, 40, 60)) -> bytes:
@@ -128,6 +139,7 @@ class ReolinkSnapshotConfigurationTests(unittest.TestCase):
             Path("/var/lib/gate-controller/uploads/.reolink-snapshots"),
         )
         self.assertTrue(config.allow_self_signed)
+        self.assertNotIn("camera-user", repr(config))
         self.assertNotIn("camera-password", repr(config))
 
     def test_missing_all_camera_credentials_disables_augmentation_but_partial_config_fails(self):
@@ -272,6 +284,24 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
             environment, root / "uploads", max_candidate_bytes=1024 * 1024
         )
 
+    def test_descriptor_anchored_snapshot_stages_evidence_for_outbox_queueing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            snapshot_spool = _SnapshotSpool(root / ".reolink-snapshots")
+            snapshot = snapshot_spool.store("capture-1.jpg", jpeg_bytes())
+            try:
+                worker = OutboxWorker(LocalStore(root / "gate.db"), send=lambda _: None)
+
+                payload = worker.prepare_payload(snapshot)
+
+                self.assertIn("image_sha256", payload)
+                self.assertTrue(
+                    (root / "event-evidence" / f"{payload['image_sha256']}.jpg").is_file()
+                )
+            finally:
+                snapshot.unlink(missing_ok=True)
+                snapshot_spool.close()
+
     def test_ftp_candidate_flushes_while_two_snapshots_form_a_later_progressive_burst(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -295,8 +325,13 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
                 SnapshotResponse(jpeg_bytes((10, 20, 30)), "image/jpeg"),
                 SnapshotResponse(jpeg_bytes((40, 50, 60)), "image/jpeg"),
             ), on_snapshot=advance)
+
+            def complete(paths, captured_at):
+                for path in paths:
+                    augmentation_collector.add(path, captured_at)
+
             sampler = ReolinkSnapshotSampler(
-                self.create_config(root), augmentation_collector.add,
+                self.create_config(root), complete,
                 client_factory=lambda _: client, clock=clock,
                 run_id=lambda: "capture",
             )
@@ -361,6 +396,24 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
             self.assertIn("reason=timeout", "\n".join(logs.output))
             self.assertTrue(ftp.exists())
 
+    def test_failed_sampling_completes_the_trigger_with_no_snapshot_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            received_at = datetime(2026, 8, 19, 18, 30, tzinfo=timezone.utc)
+            completed = []
+            sampler = ReolinkSnapshotSampler(
+                self.create_config(Path(directory)),
+                lambda paths, captured_at: completed.append((paths, captured_at)),
+                client_factory=lambda _: FakeClient(
+                    login_error=SnapshotFailure("login_http")
+                ),
+            )
+
+            self.assertTrue(sampler.request(received_at))
+            with self.assertLogs("gate_controller.reolink_snapshots", level="WARNING"):
+                self.assertTrue(sampler.run_once(Event()))
+
+            self.assertEqual(completed, [((), received_at)])
+
     def test_one_failed_run_does_not_fail_or_poison_the_sampler_component(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -368,10 +421,10 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
                 FakeClient(login_error=RuntimeError("private camera detail")),
                 FakeClient((SnapshotResponse(jpeg_bytes(), "image/jpeg"),)),
             ))
-            collected = []
+            completed = []
             sampler = ReolinkSnapshotSampler(
                 self.create_config(root, GATE_REOLINK_SNAPSHOT_COUNT="1"),
-                lambda path, received_at: collected.append(path),
+                lambda paths, received_at: completed.append(paths),
                 client_factory=lambda _: next(clients),
                 run_id=lambda: "capture",
             )
@@ -385,14 +438,14 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
             with self.assertLogs("gate_controller.reolink_snapshots", level="INFO"):
                 self.assertTrue(sampler.run_once(Event()))
 
-            self.assertEqual(len(collected), 1)
+            self.assertEqual([len(paths) for paths in completed], [0, 1])
             self.assertFalse(sampler.active)
 
     def test_run_setup_failure_is_isolated_and_the_next_request_can_succeed(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             run_ids = iter((RuntimeError("private entropy detail"), "capture"))
-            collected = []
+            completed = []
 
             def next_run_id():
                 result = next(run_ids)
@@ -403,7 +456,7 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
             client = FakeClient((SnapshotResponse(jpeg_bytes(), "image/jpeg"),))
             sampler = ReolinkSnapshotSampler(
                 self.create_config(root, GATE_REOLINK_SNAPSHOT_COUNT="1"),
-                lambda path, received_at: collected.append(path),
+                lambda paths, received_at: completed.append(paths),
                 client_factory=lambda _: client,
                 run_id=next_run_id,
             )
@@ -417,7 +470,7 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
             with self.assertLogs("gate_controller.reolink_snapshots", level="INFO"):
                 self.assertTrue(sampler.run_once(Event()))
 
-            self.assertEqual(len(collected), 1)
+            self.assertEqual([len(paths) for paths in completed], [0, 1])
 
     def test_single_flight_rejects_a_second_request_while_sampling_is_active(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -428,6 +481,150 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
 
             self.assertTrue(sampler.request())
             self.assertFalse(sampler.request())
+
+    def test_stop_before_sampler_loop_terminally_completes_the_accepted_request_once(self):
+        with tempfile.TemporaryDirectory() as directory:
+            received_at = datetime(2026, 8, 20, 9, 30, tzinfo=timezone.utc)
+            completed = []
+            client_calls = []
+            sampler = ReolinkSnapshotSampler(
+                self.create_config(Path(directory)),
+                lambda paths, captured_at: completed.append((paths, captured_at)),
+                client_factory=lambda _: client_calls.append(True),
+            )
+            stop_event = Event()
+            self.assertTrue(sampler.request(received_at))
+            stop_event.set()
+
+            sampler.run_forever(stop_event)
+            sampler.close()
+
+            self.assertEqual(completed, [((), received_at)])
+            self.assertEqual(client_calls, [])
+            self.assertFalse(sampler.active)
+
+    def test_blocking_client_obeys_total_wall_clock_budget_without_spawning_more_work(self):
+        with tempfile.TemporaryDirectory() as directory:
+            entered = Event()
+            release = Event()
+
+            class BlockingClient(FakeClient):
+                def login(self, timeout):
+                    self.login_calls += 1
+                    entered.set()
+                    release.wait(timeout=1)
+                    return "private-camera-token"
+
+            client = BlockingClient((SnapshotResponse(jpeg_bytes(), "image/jpeg"),))
+            completed = []
+            sampler = ReolinkSnapshotSampler(
+                self.create_config(
+                    Path(directory), GATE_REOLINK_SNAPSHOT_COUNT="1",
+                    GATE_REOLINK_SNAPSHOT_TIMEOUT_SECONDS="0.05",
+                ),
+                lambda paths, received_at: completed.append(paths),
+                client_factory=lambda _: client,
+            )
+            self.assertTrue(sampler.request())
+
+            started_at = monotonic()
+            with self.assertLogs("gate_controller.reolink_snapshots", level="WARNING"):
+                self.assertTrue(sampler.run_once(Event()))
+            elapsed = monotonic() - started_at
+
+            self.assertTrue(entered.is_set())
+            self.assertLess(elapsed, 0.12)
+            self.assertTrue(sampler.active)
+            self.assertFalse(sampler.request())
+            sampler.close()
+            self.assertTrue(sampler.active)
+            release.set()
+            deadline = monotonic() + 0.5
+            while sampler.active and monotonic() < deadline:
+                sleep(0.005)
+            self.assertFalse(sampler.active)
+            self.assertEqual(client.snapshot_calls, 0)
+            self.assertEqual(client.logout_calls, 0)
+            self.assertEqual(completed, [()])
+
+    def test_timeout_race_reports_one_terminal_completion(self):
+        with tempfile.TemporaryDirectory() as directory:
+            release = Event()
+
+            class CancelReleasedClient(FakeClient):
+                def login(self, timeout):
+                    release.wait(timeout=1)
+                    return "private-camera-token"
+
+            class RacingSampler(ReolinkSnapshotSampler):
+                def _cancel_active_operation(self, reason):
+                    super()._cancel_active_operation(reason)
+                    release.set()
+                    sleep(0.03)
+
+            sampler = RacingSampler(
+                self.create_config(
+                    Path(directory), GATE_REOLINK_SNAPSHOT_COUNT="1",
+                    GATE_REOLINK_SNAPSHOT_TIMEOUT_SECONDS="0.02",
+                ),
+                lambda *_: None,
+                client_factory=lambda _: CancelReleasedClient(),
+            )
+            self.assertTrue(sampler.request())
+
+            with self.assertLogs(
+                "gate_controller.reolink_snapshots", level="WARNING"
+            ) as logs:
+                self.assertTrue(sampler.run_once(Event()))
+
+            terminal_logs = [
+                line for line in logs.output if "outcome=failed" in line
+            ]
+            self.assertEqual(len(terminal_logs), 1)
+
+    def test_close_defers_spool_cleanup_until_a_live_operation_has_terminated(self):
+        with tempfile.TemporaryDirectory() as directory:
+            entered_logout = Event()
+            release_logout = Event()
+
+            class BlockingLogoutClient(FakeClient):
+                def logout(self, token, timeout):
+                    self.logout_calls += 1
+                    entered_logout.set()
+                    release_logout.wait(timeout=1)
+
+            client = BlockingLogoutClient((
+                SnapshotResponse(jpeg_bytes(), "image/jpeg"),
+            ))
+            completed = []
+            sampler = ReolinkSnapshotSampler(
+                self.create_config(
+                    Path(directory), GATE_REOLINK_SNAPSHOT_COUNT="1",
+                    GATE_REOLINK_SNAPSHOT_TIMEOUT_SECONDS="0.05",
+                ),
+                lambda paths, received_at: completed.append(paths),
+                client_factory=lambda _: client,
+                run_id=lambda: "capture",
+            )
+            self.assertTrue(sampler.request())
+
+            with self.assertLogs("gate_controller.reolink_snapshots", level="WARNING"):
+                self.assertTrue(sampler.run_once(Event()))
+            generated = sampler.output_directory / "capture-01.jpg"
+            self.assertTrue(entered_logout.is_set())
+            self.assertTrue(generated.exists())
+
+            sampler.close()
+            self.assertTrue(sampler.active)
+            self.assertTrue(generated.exists())
+            release_logout.set()
+            deadline = monotonic() + 0.5
+            while sampler.active and monotonic() < deadline:
+                sleep(0.005)
+
+            self.assertFalse(sampler.active)
+            self.assertFalse(generated.exists())
+            self.assertEqual(completed, [()])
 
     def test_invalid_content_oversized_and_non_jpeg_responses_are_removed(self):
         cases = (
@@ -454,31 +651,6 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
                 self.assertIn(f"reason={reason}", "\n".join(logs.output))
                 self.assertEqual(list(sampler.output_directory.glob("*.jpg")), [])
 
-    def test_cleanup_error_does_not_replace_the_original_store_failure(self):
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            client = FakeClient((SnapshotResponse(jpeg_bytes(), "image/jpeg"),))
-            sampler = ReolinkSnapshotSampler(
-                self.create_config(root, GATE_REOLINK_SNAPSHOT_COUNT="1"),
-                lambda *_: self.fail("failed sample reached the collector"),
-                client_factory=lambda _: client, run_id=lambda: "capture",
-            )
-            self.assertTrue(sampler.request())
-
-            with patch(
-                "gate_controller.reolink_snapshots.os.replace",
-                side_effect=SnapshotFailure("store_failed"),
-            ), patch(
-                "gate_controller.reolink_snapshots.os.unlink",
-                side_effect=PermissionError("private cleanup detail"),
-            ), self.assertLogs(
-                "gate_controller.reolink_snapshots", level="WARNING",
-            ) as logs:
-                self.assertTrue(sampler.run_once(Event()))
-
-            self.assertIn("outcome=failed", "\n".join(logs.output))
-            self.assertIn("reason=store_failed", "\n".join(logs.output))
-
     def test_generated_snapshot_directory_is_ignored_and_shutdown_cleans_it(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -486,14 +658,14 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
             uploads.mkdir()
             config = self.create_config(root)
             config.output_directory.mkdir(mode=0o700)
+            generated = config.output_directory / "old.jpg"
+            generated.write_bytes(jpeg_bytes())
             ftp = uploads / "camera.jpg"
             ftp.write_bytes(jpeg_bytes())
             collected = []
             sample_requests = []
             collector = BurstCollector(lambda paths: collected.append(paths))
             sampler = ReolinkSnapshotSampler(config, collector.add)
-            generated = config.output_directory / "old.jpg"
-            generated.write_bytes(jpeg_bytes())
             handler = CompletedImageHandler(
                 collector, on_first_completed=lambda received_at: sample_requests.append(received_at),
                 ignored_roots=(config.output_directory,),
@@ -541,7 +713,7 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
             collected = []
 
             sampler = ReolinkSnapshotSampler(
-                config, lambda path, received_at: collected.append(path),
+                config, lambda paths, received_at: collected.extend(paths),
                 client_factory=lambda _: self.fail("camera client must not be opened"),
             )
             self.assertTrue(sampler.request())
@@ -550,26 +722,218 @@ class ReolinkSnapshotSamplerTests(unittest.TestCase):
 
             self.assertEqual(collected, [])
             self.assertTrue(keep.exists())
+            self.assertTrue(config.output_directory.is_symlink())
             self.assertIn("outcome=failed", "\n".join(logs.output))
             self.assertIn("reason=io_error", "\n".join(logs.output))
 
-    def test_sampler_exposes_candidates_to_ocr_without_a_direct_actuation_path(self):
+    def test_stored_candidate_validation_stays_anchored_after_spool_path_replacement(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            ocr_candidates = []
-            client = FakeClient((SnapshotResponse(jpeg_bytes(), "image/jpeg"),))
-            sampler = ReolinkSnapshotSampler(
-                self.create_config(root, GATE_REOLINK_SNAPSHOT_COUNT="1"),
-                lambda path, received_at: ocr_candidates.append((path, received_at)),
-                client_factory=lambda _: client,
-                run_id=lambda: "capture",
+            spool_path = root / ".reolink-snapshots"
+            private_spool = root / "private-spool"
+            external = root / "external"
+            external.mkdir()
+            spool = _SnapshotSpool(spool_path)
+            candidate = spool.store("capture-01.jpg", jpeg_bytes())
+            spool_path.rename(private_spool)
+            (external / "capture-01.jpg").write_bytes(b"not-a-jpeg")
+            spool_path.symlink_to(external, target_is_directory=True)
+
+            try:
+                self.assertTrue(
+                    wait_until_readable(candidate, timeout=0, poll_interval=0)
+                )
+            finally:
+                close = getattr(candidate, "close", None)
+                if callable(close):
+                    close()
+                spool.close()
+
+    def test_worker_cleanup_stays_anchored_after_spool_path_replacement(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            spool_path = root / ".reolink-snapshots"
+            private_spool = root / "private-spool"
+            external = root / "external"
+            external.mkdir()
+            sentinel = external / "capture-01.jpg"
+            sentinel.write_bytes(jpeg_bytes())
+            spool = _SnapshotSpool(spool_path)
+            candidate = spool.store("capture-01.jpg", jpeg_bytes((80, 90, 100)))
+            spool_path.rename(private_spool)
+            spool_path.symlink_to(external, target_is_directory=True)
+
+            try:
+                _remove_upload(candidate)
+                self.assertTrue(sentinel.exists())
+                self.assertFalse((private_spool / "capture-01.jpg").exists())
+            finally:
+                close = getattr(candidate, "close", None)
+                if callable(close):
+                    close()
+                spool.close()
+
+    def test_disabled_sampler_never_traverses_or_deletes_a_symlinked_spool_target(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            external = root / "external"
+            external.mkdir()
+            sentinel = external / "keep.jpg"
+            sentinel.write_bytes(jpeg_bytes())
+            config = replace(
+                self.create_config(root),
+                base_url=None,
+                username=None,
+                password=None,
+                output_directory=root / ".reolink-snapshots",
+                disabled_reason="unconfigured",
+            )
+            config.output_directory.symlink_to(external, target_is_directory=True)
+
+            sampler = ReolinkSnapshotSampler(config, lambda *_: None)
+            sampler.close()
+
+            self.assertTrue(sentinel.exists())
+            self.assertTrue(config.output_directory.is_symlink())
+
+    def test_disabled_sampler_does_not_initialize_a_spool(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = replace(
+                self.create_config(Path(directory)),
+                base_url=None,
+                username=None,
+                password=None,
+                output_directory=Path(directory) / "unwritable" / ".reolink-snapshots",
+                disabled_reason="unconfigured",
             )
 
-            self.assertNotIn("relay", sampler.__dict__)
-            self.assertTrue(sampler.request())
-            sampler.run_once(Event())
+            with patch(
+                "gate_controller.reolink_snapshots._SnapshotSpool",
+                side_effect=AssertionError("disabled sampler touched the spool"),
+            ):
+                sampler = ReolinkSnapshotSampler(config, lambda *_: None)
+                sampler.close()
 
-            self.assertEqual(len(ocr_candidates), 1)
+    def test_uncorrelated_snapshot_completion_cannot_reach_processor_or_relay(self):
+        class AuthorisedRecognizer:
+            def recognise(self, path):
+                return PlateObservation("12D3456", 0.99)
+
+        class RecordingRelay:
+            def trigger(self, source, idempotency_key=None, **kwargs):
+                relay_calls.append((source, idempotency_key))
+                return RelayResult(
+                    activated=True,
+                    reason="activated",
+                    idempotency_key=idempotency_key,
+                )
+
+        class RecordingProcessor(GateProcessor):
+            def process(self, *args, **kwargs):
+                processor_calls.append((args, kwargs))
+                return super().process(*args, **kwargs)
+
+        class TrackingBurstQueue(BoundedBurstQueue):
+            def put(self, item):
+                if item is not None:
+                    work_enqueued.set()
+                return super().put(item)
+
+            def put_augmentation(self, item):
+                work_enqueued.set()
+                return super().put_augmentation(item)
+
+            def get(self):
+                processor_waiting.set()
+                item = super().get()
+                if item is not None:
+                    work_dequeued.set()
+                return item
+
+        class PassiveObserver:
+            def schedule(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+            def join(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relay_calls = []
+            processor_calls = []
+            processor_waiting = Event()
+            work_enqueued = Event()
+            work_dequeued = Event()
+            snapshot_completed = Event()
+            snapshot_directory = root / ".reolink-snapshots"
+            snapshot_directory.mkdir()
+            snapshot = snapshot_directory / "capture-01.jpg"
+            snapshot.write_bytes(jpeg_bytes())
+            received_at = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+            class SnapshotOnlySampler:
+                output_directory = snapshot_directory
+
+                def __init__(self, config, complete):
+                    self._complete = complete
+
+                def request(self, received_at=None):
+                    raise AssertionError(
+                        "snapshot-only test sampler received an FTP trigger"
+                    )
+
+                def run_forever(self, stop_event):
+                    if not processor_waiting.wait(timeout=1):
+                        raise AssertionError("processor did not begin waiting for work")
+                    self._complete((snapshot,), received_at)
+                    snapshot_completed.set()
+                    stop_event.wait()
+
+                def close(self):
+                    pass
+
+            processor = RecordingProcessor(
+                recognizer=AuthorisedRecognizer(),
+                store=LocalStore(root / "gate.db"),
+                relay=RecordingRelay(),
+                authorised={"12D3456"},
+                cooldown=timedelta(seconds=0),
+                max_image_age=timedelta(minutes=5),
+                clock=lambda: received_at,
+            )
+
+            def stop_after_snapshot(_):
+                self.assertTrue(snapshot_completed.wait(timeout=1))
+                if work_enqueued.is_set():
+                    self.assertTrue(work_dequeued.wait(timeout=1))
+                raise KeyboardInterrupt
+
+            with patch(
+                "gate_controller.worker.ReolinkSnapshotSampler", SnapshotOnlySampler
+            ), patch(
+                "gate_controller.worker.BoundedBurstQueue", TrackingBurstQueue
+            ), patch(
+                "gate_controller.worker.Observer", return_value=PassiveObserver()
+            ), patch(
+                "gate_controller.worker.current_thread_is_main", return_value=False
+            ), patch(
+                "gate_controller.worker.sleep", side_effect=stop_after_snapshot
+            ):
+                run_worker(
+                    root,
+                    processor.process,
+                    snapshot_sampling=type("Config", (), {"enabled": True})(),
+                )
+
+            self.assertEqual(processor_calls, [])
+            self.assertEqual(relay_calls, [])
+            self.assertFalse(snapshot.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,10 +2,13 @@ import unittest
 import tempfile
 import os
 import signal
+import gate_controller.worker as worker_module
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Event as ThreadEvent, Thread
 from unittest.mock import patch
+
+from PIL import Image
 
 from gate_controller.worker import (
     BoundedBurstQueue, BurstCollector, CompletedImageHandler, StartupReconciler,
@@ -15,6 +18,7 @@ from gate_controller.worker import (
     _install_sigterm_handler,
     run_worker,
 )
+from gate_controller.models import ProcessingResult
 
 
 class MutableClock:
@@ -33,6 +37,14 @@ class RecordingCollector:
     def add(self, path, received_at=None):
         self.paths.append(path)
         self.received_at.append(received_at)
+
+
+class SequenceQueue:
+    def __init__(self, *items):
+        self._items = iter(items)
+
+    def get(self):
+        return next(self._items)
 
 
 class Event:
@@ -179,6 +191,61 @@ class WorkerTests(unittest.TestCase):
 
             self.assertFalse(rejected.exists())
             self.assertTrue(accepted.exists())
+
+    def test_empty_ranked_burst_abandons_its_exact_context_before_the_next_burst(self):
+        clock = MutableClock()
+        emitted = []
+        abandoned = []
+        rank_calls = []
+
+        def ranker(paths):
+            rank_calls.append(paths)
+            return () if len(rank_calls) == 1 else paths
+
+        collector = BurstCollector(
+            emitted.append,
+            quiet_window=0.5,
+            ranker=ranker,
+            clock=clock,
+            include_received_at=True,
+            on_abandoned=abandoned.append,
+        )
+        received_a = datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc)
+        received_b = received_a + timedelta(seconds=1)
+        collector.add(Path("a.jpg"), received_a)
+        collector.bind_context("trigger-a")
+        clock.value = 0.5
+
+        self.assertFalse(collector.flush_due())
+
+        collector.add(Path("b.jpg"), received_b)
+        collector.bind_context("trigger-b")
+        clock.value = 1.0
+        self.assertTrue(collector.flush_due())
+
+        self.assertEqual(abandoned, ["trigger-a"])
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(emitted[0].context, "trigger-b")
+        self.assertEqual(emitted[0].item[:2], ((Path("b.jpg"),), received_b))
+
+    def test_abandoning_trigger_releases_unsubmitted_reservation_and_snapshot_files(self):
+        queue = BoundedBurstQueue(max_pending=1)
+        released = []
+        with tempfile.TemporaryDirectory() as directory:
+            snapshot = Path(directory) / "snapshot.jpg"
+            snapshot.write_bytes(b"snapshot")
+            trigger = worker_module.ProgressiveTrigger(
+                datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc),
+                release=lambda: released.append(True),
+                snapshots=(snapshot,),
+            )
+            self.assertTrue(queue.reserve_augmentation())
+
+            worker_module._abandon_progressive_trigger(trigger, queue)
+
+            self.assertFalse(snapshot.exists())
+            self.assertEqual(released, [True])
+            self.assertTrue(queue.reserve_augmentation())
 
     def test_burst_decision_clock_starts_before_ranking(self):
         clock = MutableClock()
@@ -569,16 +636,231 @@ class WorkerTests(unittest.TestCase):
         self.assertEqual(dropped, (Path("first.jpg"),))
         self.assertEqual(queue.get(), (Path("second.jpg"),))
 
-    def test_optional_queue_admission_never_evicts_primary_work(self):
+    def test_reserved_augmentation_never_evicts_or_precedes_ftp_work(self):
         queue = BoundedBurstQueue(max_pending=1)
-        primary = (Path("primary-ftp.jpg"),)
-        augmentation = (Path("optional-snapshot.jpg"),)
+        ftp = ((Path("ftp.jpg"),), "ftp")
+        snapshots = ((Path("snapshot.jpg"),), "augmentation")
 
-        queue.put(primary)
-        accepted = queue.try_put(augmentation)
+        self.assertTrue(queue.reserve_augmentation())
+        self.assertIsNone(queue.put(ftp))
+        self.assertIsNone(queue.put_augmentation(snapshots))
 
-        self.assertFalse(accepted)
-        self.assertEqual(queue.get(), primary)
+        self.assertEqual(queue.get(), ftp)
+        self.assertEqual(queue.get(), snapshots)
+
+    def test_final_progressive_selection_can_include_an_anchored_snapshot(self):
+        class AnchoredSnapshot:
+            _descriptor_anchored = True
+
+            def __init__(self):
+                self.unlinked = 0
+
+            def unlink(self, missing_ok=False):
+                self.unlinked += 1
+
+        received_at = datetime(2026, 8, 20, 11, 0, tzinfo=timezone.utc)
+        ftp = tuple(Path(f"ftp-{index}.jpg") for index in range(4))
+        snapshot = AnchoredSnapshot()
+        trigger = worker_module.ProgressiveTrigger(received_at)
+        primary = worker_module.BurstWork(
+            "primary", (ftp, received_at), trigger,
+        )
+        augmentation = worker_module.BurstWork(
+            "augmentation", ((snapshot,), received_at), trigger,
+        )
+        calls = []
+
+        def emit(paths, captured_at, *timing, **options):
+            calls.append((paths, captured_at, options))
+            return ProcessingResult(
+                False, "no_match", idempotency_key="progressive-event",
+                terminal=False,
+            )
+
+        with patch(
+            "gate_controller.worker.rank_images",
+            return_value=(snapshot, ftp[3], ftp[2], ftp[1], ftp[0]),
+        ):
+            _process_bursts(SequenceQueue(primary, augmentation, None), emit)
+
+        self.assertEqual(calls[0], (ftp, received_at, {"final": False}))
+        self.assertEqual(calls[1][0], (snapshot, ftp[3], ftp[2]))
+        self.assertIs(calls[1][0][0], snapshot)
+        self.assertEqual(calls[1][2], {
+            "idempotency_key": "progressive-event",
+            "final": True,
+            "augmentation": {
+                "outcome": "completed",
+                "reason": "completed",
+                "candidate_count": 1,
+                "duration_ms": 0,
+                "correlation": "progressive-event",
+            },
+        })
+        self.assertEqual(snapshot.unlinked, 1)
+
+    def test_shutdown_discards_reserved_and_future_work_idempotently(self):
+        discarded = []
+        queue = BoundedBurstQueue(
+            max_pending=1,
+            on_discard=lambda stopped_queue, item: discarded.append(item),
+        )
+        augmentation = ((Path("snapshot.jpg"),), "augmentation")
+        future_primary = ((Path("future-ftp.jpg"),), "ftp")
+        future_augmentation = ((Path("future-snapshot.jpg"),), "augmentation")
+
+        self.assertTrue(queue.reserve_augmentation())
+        queue.put_augmentation(augmentation)
+        queue.put(None)
+        queue.put(future_primary)
+        queue.put_augmentation(future_augmentation)
+        queue.put(None)
+
+        self.assertIsNone(queue.get())
+        self.assertFalse(queue.reserve_augmentation())
+        self.assertEqual(
+            discarded, [augmentation, future_primary, future_augmentation]
+        )
+
+    def test_shutdown_does_not_emit_queued_primary_or_augmentation_work(self):
+        queue = BoundedBurstQueue(max_pending=2)
+        received_at = datetime(2026, 8, 20, 11, 0, tzinfo=timezone.utc)
+        emitted = []
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ordinary = root / "ordinary.jpg"
+            progressive = root / "progressive.jpg"
+            snapshot = root / "snapshot.jpg"
+            for path in (ordinary, progressive, snapshot):
+                path.write_bytes(b"candidate")
+            trigger = worker_module.ProgressiveTrigger(
+                received_at, snapshots=(snapshot,), augmentation_submitted=True,
+            )
+            queue.put(((ordinary,), received_at))
+            queue.put(worker_module.BurstWork(
+                "primary", ((progressive,), received_at), trigger,
+            ))
+            self.assertTrue(queue.reserve_augmentation())
+            queue.put_augmentation(worker_module.BurstWork(
+                "augmentation", ((snapshot,), received_at), trigger,
+            ))
+            queue.put(None)
+
+            def emit(paths, captured_at, *timing, **options):
+                emitted.append((paths, captured_at, options))
+                return ProcessingResult(
+                    False, "no_match", idempotency_key="queued-trigger",
+                    terminal=False,
+                )
+
+            _process_bursts(queue, emit)
+
+        self.assertEqual(emitted, [])
+
+    def test_shutdown_cleanup_removes_paths_and_abandons_shared_trigger_once(self):
+        received_at = datetime(2026, 8, 20, 11, 5, tzinfo=timezone.utc)
+        released = []
+        queue = BoundedBurstQueue(
+            max_pending=2,
+            on_discard=lambda stopped_queue, item: (
+                worker_module._discard_burst_work(item, stopped_queue)
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ordinary = root / "ordinary.jpg"
+            progressive = root / "progressive.jpg"
+            snapshot = root / "snapshot.jpg"
+            future = root / "future.jpg"
+            for path in (ordinary, progressive, snapshot, future):
+                path.write_bytes(b"candidate")
+            trigger = worker_module.ProgressiveTrigger(
+                received_at,
+                release=lambda: released.append(True),
+                snapshots=(snapshot,),
+                augmentation_submitted=True,
+            )
+            queue.put(((ordinary,), received_at))
+            queue.put(worker_module.BurstWork(
+                "primary", ((progressive,), received_at), trigger,
+            ))
+            self.assertTrue(queue.reserve_augmentation())
+            queue.put_augmentation(worker_module.BurstWork(
+                "augmentation", ((snapshot,), received_at), trigger,
+            ))
+
+            queue.put(None)
+            queue.put(((future,), received_at))
+            queue.put(None)
+
+            self.assertFalse(any(
+                path.exists() for path in (ordinary, progressive, snapshot, future)
+            ))
+            self.assertTrue(trigger.abandoned)
+            self.assertEqual(released, [True])
+            self.assertIsNone(queue.get())
+
+    def test_shutdown_terminalizes_a_computed_provisional_result_when_sampler_completes(self):
+        received_at = datetime(2026, 8, 20, 11, 10, tzinfo=timezone.utc)
+        initial_processed = ThreadEvent()
+        calls = []
+        terminal_candidate_existence = []
+        queue = BoundedBurstQueue(
+            max_pending=1,
+            on_discard=lambda stopped_queue, item: (
+                worker_module._discard_burst_work(item, stopped_queue)
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            primary = root / "ftp.jpg"
+            snapshot = root / "snapshot.jpg"
+            primary.write_bytes(b"ftp")
+            snapshot.write_bytes(b"snapshot")
+            trigger = worker_module.ProgressiveTrigger(received_at)
+            queue.put(worker_module.BurstWork(
+                "primary", ((primary,), received_at), trigger,
+            ))
+
+            def emit(paths, captured_at, *timing, **options):
+                calls.append((paths, captured_at, options))
+                if not options.get("final"):
+                    initial_processed.set()
+                    return ProcessingResult(
+                        False, "no_match", idempotency_key="shutdown-event",
+                        terminal=False,
+                    )
+                terminal_candidate_existence.append((
+                    primary.exists(), snapshot.exists(),
+                ))
+                return ProcessingResult(
+                    False, "no_match", idempotency_key="shutdown-event",
+                )
+
+            processor = Thread(target=_process_bursts, args=(queue, emit))
+            processor.start()
+            self.assertTrue(initial_processed.wait(timeout=1))
+            queue.put(None)
+            processor.join(timeout=1)
+            self.assertFalse(processor.is_alive())
+
+            with trigger._lock:
+                trigger.snapshots = (snapshot,)
+                trigger.augmentation_submitted = True
+            queue.put_augmentation(worker_module.BurstWork(
+                "augmentation", ((snapshot,), received_at), trigger,
+            ))
+
+            self.assertFalse(primary.exists())
+            self.assertFalse(snapshot.exists())
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][2], {"final": False})
+        self.assertEqual(calls[1][2]["final"], True)
+        self.assertEqual(calls[1][2]["provisional_result"], ProcessingResult(
+            False, "no_match", idempotency_key="shutdown-event", terminal=False,
+        ))
+        self.assertEqual(terminal_candidate_existence, [(True, True)])
 
     def test_burst_received_at_uses_first_filesystem_arrival_not_image_mtime(self):
         monotonic_clock = MutableClock()
@@ -610,15 +892,12 @@ class WorkerTests(unittest.TestCase):
         )
 
     def test_processing_exception_is_forwarded_to_observable_error_handler(self):
-        queue = BoundedBurstQueue(max_pending=2)
         received_at = datetime(2026, 8, 14, 10, 0, tzinfo=timezone.utc)
         paths = (Path("failed.jpg"),)
         errors = []
-        queue.put((paths, received_at))
-        queue.put(None)
 
         _process_bursts(
-            queue,
+            SequenceQueue((paths, received_at), None),
             lambda *_: (_ for _ in ()).throw(RuntimeError("processor failed")),
             lambda caught_paths, error, caught_at: errors.append(
                 (caught_paths, str(error), caught_at)
@@ -628,27 +907,194 @@ class WorkerTests(unittest.TestCase):
         self.assertEqual(errors, [(paths, "processor failed", received_at)])
 
     def test_processed_upload_is_removed_after_emit_returns(self):
-        queue = BoundedBurstQueue(max_pending=2)
         received_at = datetime(2026, 8, 14, 10, 0, tzinfo=timezone.utc)
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "processed.jpg"
             path.write_bytes(b"camera upload")
-            queue.put(((path,), received_at))
-            queue.put(None)
 
-            _process_bursts(queue, lambda *_: None)
+            _process_bursts(
+                SequenceQueue(((path,), received_at), None), lambda *_: None
+            )
 
             self.assertFalse(path.exists())
 
+    def test_progressive_work_reuses_ftp_identity_and_retains_it_until_terminal_result(self):
+        received_at = datetime(2026, 8, 19, 18, 30, tzinfo=timezone.utc)
+        released = []
+        calls = []
+        with tempfile.TemporaryDirectory() as directory:
+            ftp = Path(directory) / "ftp.jpg"
+            snapshot = Path(directory) / "snapshot.jpg"
+            Image.new("RGB", (32, 24), color="red").save(ftp, format="JPEG")
+            Image.new("RGB", (32, 24), color="blue").save(snapshot, format="JPEG")
+            trigger = worker_module.ProgressiveTrigger(
+                received_at, release=lambda: released.append(True)
+            )
+            items = iter((
+                worker_module.BurstWork("primary", ((ftp,), received_at), trigger),
+                worker_module.BurstWork(
+                    "augmentation", ((snapshot,), received_at), trigger
+                ),
+                None,
+            ))
+
+            class WorkQueue:
+                def get(self):
+                    return next(items)
+
+            def emit(paths, captured_at, *timing, **options):
+                calls.append((paths, captured_at, options))
+                if len(calls) == 1:
+                    return ProcessingResult(
+                        False, "no_match", idempotency_key="ftp-trigger",
+                        terminal=False,
+                    )
+                return ProcessingResult(
+                    True, "activated", event_id=1,
+                    idempotency_key="ftp-trigger", terminal=True,
+                )
+
+            _process_bursts(WorkQueue(), emit, ranker=lambda candidates: candidates)
+
+            self.assertEqual(calls[0][0], (ftp,))
+            self.assertEqual(calls[0][2], {"final": False})
+            self.assertEqual(calls[1][0], (ftp, snapshot))
+            self.assertEqual(calls[1][2], {
+                "idempotency_key": "ftp-trigger", "final": True,
+                "augmentation": {
+                    "outcome": "completed",
+                    "reason": "completed",
+                    "candidate_count": 1,
+                    "duration_ms": 0,
+                    "correlation": "ftp-trigger",
+                },
+            })
+            self.assertFalse(ftp.exists())
+            self.assertFalse(snapshot.exists())
+            self.assertEqual(released, [True])
+
+    def test_throwing_final_ranker_releases_progressive_candidates(self):
+        received_at = datetime(2026, 8, 20, 12, 30, tzinfo=timezone.utc)
+        released = []
+        errors = []
+        with tempfile.TemporaryDirectory() as directory:
+            ftp = Path(directory) / "ftp.jpg"
+            snapshot = Path(directory) / "snapshot.jpg"
+            ftp.write_bytes(b"ftp")
+            snapshot.write_bytes(b"snapshot")
+            trigger = worker_module.ProgressiveTrigger(
+                received_at, release=lambda: released.append(True),
+            )
+            items = iter((
+                worker_module.BurstWork("primary", ((ftp,), received_at), trigger),
+                worker_module.BurstWork(
+                    "augmentation", ((snapshot,), received_at), trigger
+                ),
+                None,
+            ))
+
+            class WorkQueue:
+                def get(self):
+                    return next(items)
+
+            _process_bursts(
+                WorkQueue(),
+                lambda *_args, **_kwargs: ProcessingResult(
+                    False, "no_match", idempotency_key="ftp-trigger", terminal=False,
+                ),
+                lambda paths, error, captured_at: errors.append(
+                    (paths, str(error), captured_at)
+                ),
+                ranker=lambda _paths: (_ for _ in ()).throw(RuntimeError("rank failed")),
+            )
+
+            self.assertTrue(trigger.finalized)
+            self.assertEqual(errors, [((ftp, snapshot), "rank failed", received_at)])
+            self.assertFalse(ftp.exists())
+            self.assertFalse(snapshot.exists())
+            self.assertEqual(released, [True])
+
+    def test_late_augmentation_cleans_after_its_primary_work_was_coalesced(self):
+        received_at = datetime(2026, 8, 19, 18, 30, tzinfo=timezone.utc)
+        released = []
+        with tempfile.TemporaryDirectory() as directory:
+            snapshot = Path(directory) / "snapshot.jpg"
+            snapshot.write_bytes(b"snapshot")
+            trigger = worker_module.ProgressiveTrigger(
+                received_at, release=lambda: released.append(True), failed=True,
+            )
+            items = iter((
+                worker_module.BurstWork(
+                    "augmentation", ((snapshot,), received_at), trigger
+                ),
+                None,
+            ))
+
+            class WorkQueue:
+                def get(self):
+                    return next(items)
+
+            _process_bursts(
+                WorkQueue(), lambda *_args, **_kwargs: self.fail(
+                    "coalesced trigger reached processing"
+                )
+            )
+
+            self.assertFalse(snapshot.exists())
+            self.assertEqual(released, [True])
+
+    def test_empty_augmentation_finalizes_the_original_provisional_result(self):
+        received_at = datetime(2026, 8, 19, 18, 30, tzinfo=timezone.utc)
+        calls = []
+        provisional = ProcessingResult(
+            False, "no_match", idempotency_key="ftp-trigger", terminal=False,
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            ftp = Path(directory) / "ftp.jpg"
+            ftp.write_bytes(b"ftp")
+            trigger = worker_module.ProgressiveTrigger(received_at)
+            items = iter((
+                worker_module.BurstWork("primary", ((ftp,), received_at), trigger),
+                worker_module.BurstWork("augmentation", ((), received_at), trigger),
+                None,
+            ))
+
+            class WorkQueue:
+                def get(self):
+                    return next(items)
+
+            def emit(paths, captured_at, *timing, **options):
+                calls.append(options)
+                return provisional if len(calls) == 1 else ProcessingResult(
+                    False, "no_match", event_id=1,
+                    idempotency_key="ftp-trigger", terminal=True,
+                )
+
+            _process_bursts(WorkQueue(), emit)
+
+            self.assertEqual(calls[0], {"final": False})
+            self.assertEqual(calls[1], {
+                "idempotency_key": "ftp-trigger",
+                "final": True,
+                "provisional_result": provisional,
+                "augmentation": {
+                    "outcome": "failed",
+                    "reason": "empty",
+                    "candidate_count": 0,
+                    "duration_ms": 0,
+                },
+            })
+            self.assertFalse(ftp.exists())
+
     def test_processing_receives_the_preprocessing_start_time(self):
-        queue = BoundedBurstQueue(max_pending=2)
         received_at = datetime(2026, 8, 14, 10, 0, tzinfo=timezone.utc)
         paths = (Path("ranked.jpg"),)
         calls = []
-        queue.put((paths, received_at, 12.5))
-        queue.put(None)
 
-        _process_bursts(queue, lambda *args: calls.append(args))
+        _process_bursts(
+            SequenceQueue((paths, received_at, 12.5), None),
+            lambda *args: calls.append(args),
+        )
 
         self.assertEqual(calls, [(paths, received_at, 12.5)])
 
@@ -706,20 +1152,101 @@ class WorkerTests(unittest.TestCase):
         self.assertEqual(configured["handler"]["max_candidate_bytes"], 1024)
         self.assertEqual(configured["handler"]["max_pending_candidates"], 5)
 
+    def test_run_worker_stops_queued_bursts_before_controller_shutdown(self):
+        configured = {}
+        consumer_ready = ThreadEvent()
+        release_consumer = ThreadEvent()
+        consumer_finished = ThreadEvent()
+        emitted = []
+        observed_during_shutdown = []
+        real_process_bursts = worker_module._process_bursts
+
+        class Collector:
+            def __init__(self, emit, **kwargs):
+                configured["enqueue"] = emit
+
+            def flush_due(self):
+                return False
+
+        class Handler:
+            def __init__(self, collector, **kwargs):
+                pass
+
+            def retry_pending(self):
+                return 0
+
+            def schedule_candidate(self, *args):
+                pass
+
+        class OneItemQueue:
+            def __init__(self, queue):
+                self._queue = queue
+                self._consumed = False
+
+            def get(self):
+                if self._consumed:
+                    return None
+                self._consumed = True
+                return self._queue.get()
+
+        def delayed_processor(queue, emit, on_error, ranker=None):
+            consumer_ready.set()
+            release_consumer.wait(timeout=1)
+            try:
+                real_process_bursts(OneItemQueue(queue), emit, on_error, ranker)
+            finally:
+                consumer_finished.set()
+
+        with tempfile.TemporaryDirectory() as directory:
+            queued = Path(directory) / "queued.jpg"
+            received_at = datetime(2026, 8, 20, 11, 30, tzinfo=timezone.utc)
+
+            def enqueue_then_stop(_):
+                self.assertTrue(consumer_ready.wait(timeout=1))
+                queued.write_bytes(b"candidate")
+                configured["enqueue"](((queued,), received_at))
+                raise KeyboardInterrupt
+
+            def blocked_shutdown():
+                release_consumer.set()
+                self.assertTrue(consumer_finished.wait(timeout=1))
+                observed_during_shutdown.extend(emitted)
+
+            with patch(
+                "gate_controller.worker.BurstCollector", Collector
+            ), patch(
+                "gate_controller.worker.CompletedImageHandler", Handler
+            ), patch(
+                "gate_controller.worker.Observer", return_value=PassiveObserver()
+            ), patch(
+                "gate_controller.worker._process_bursts", delayed_processor
+            ), patch(
+                "gate_controller.worker.current_thread_is_main", return_value=False
+            ), patch(
+                "gate_controller.worker.sleep", side_effect=enqueue_then_stop
+            ):
+                run_worker(
+                    Path(directory), lambda *args: emitted.append(args),
+                    shutdown=blocked_shutdown,
+                )
+
+            self.assertFalse(queued.exists())
+
+        self.assertEqual(observed_during_shutdown, [])
+        self.assertEqual(emitted, [])
+
     def test_run_worker_never_defers_the_initial_ftp_burst_for_snapshot_sampling(self):
         configured = {}
         lifecycle = []
 
         class Collector:
             def __init__(self, emit, **kwargs):
-                self.index = len(configured.setdefault("collectors", []))
                 configured.setdefault("collectors", []).append(kwargs)
 
             def add(self, path, received_at=None):
                 return True
 
             def flush_due(self):
-                configured.setdefault("flushes", []).append(self.index)
                 return False
 
         class Handler:
@@ -735,8 +1262,9 @@ class WorkerTests(unittest.TestCase):
         class Sampler:
             output_directory = Path("private-snapshots")
 
-            def __init__(self, config, add_candidate):
+            def __init__(self, config, complete):
                 configured["sampler_config"] = config
+                configured["sampler_complete"] = complete
 
             def request(self, received_at=None):
                 return True
@@ -777,113 +1305,20 @@ class WorkerTests(unittest.TestCase):
                 snapshot_sampling=type("Config", (), {"enabled": True})(),
             )
 
-        self.assertEqual(len(configured["collectors"]), 2)
-        self.assertEqual(configured["collectors"][0], configured["collectors"][1])
-        self.assertEqual(configured["flushes"], [0, 1])
-        self.assertIsInstance(
-            configured["handler"]["on_first_completed"].__self__, Sampler
-        )
+        self.assertEqual(len(configured["collectors"]), 1)
+        self.assertTrue(all(
+            "defer_flush" not in options for options in configured["collectors"]
+        ))
+        self.assertIsNone(getattr(
+            configured["handler"]["on_first_completed"], "__self__", None
+        ))
+        self.assertTrue(callable(configured["sampler_complete"]))
         self.assertLess(
             lifecycle.index("thread_join:ReolinkSnapshotSampler"),
             lifecycle.index("sampler_close"),
         )
-        self.assertLess(
-            lifecycle.index("thread_join:GateBurstProcessor"),
-            lifecycle.index("sampler_close"),
-        )
 
-    def test_run_worker_uses_non_evicting_admission_for_snapshot_augmentation(self):
-        configured = {"emits": [], "queue_calls": []}
-
-        class BurstQueue:
-            def __init__(self, max_pending):
-                pass
-
-            def put(self, item):
-                configured["queue_calls"].append(("evicting", item))
-                return None
-
-            def try_put(self, item):
-                configured["queue_calls"].append(("non_evicting", item))
-                return False
-
-        class Collector:
-            def __init__(self, emit, **kwargs):
-                configured["emits"].append(emit)
-
-            def add(self, path, received_at=None):
-                return True
-
-            def flush_due(self):
-                return False
-
-        class Handler:
-            def __init__(self, collector, **kwargs):
-                pass
-
-            def retry_pending(self):
-                return 0
-
-            def schedule_candidate(self, *args):
-                pass
-
-        class Sampler:
-            output_directory = Path("private-snapshots")
-
-            def __init__(self, config, add_candidate):
-                pass
-
-            def request(self, received_at=None):
-                return True
-
-            def run_forever(self, stop_event):
-                pass
-
-            def close(self):
-                pass
-
-        class WorkerThread:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def start(self):
-                pass
-
-            def join(self, timeout=None):
-                pass
-
-        with tempfile.TemporaryDirectory() as directory, patch(
-            "gate_controller.worker.BoundedBurstQueue", BurstQueue
-        ), patch(
-            "gate_controller.worker.BurstCollector", Collector
-        ), patch(
-            "gate_controller.worker.CompletedImageHandler", Handler
-        ), patch(
-            "gate_controller.worker.ReolinkSnapshotSampler", Sampler
-        ), patch(
-            "gate_controller.worker.Observer", return_value=PassiveObserver()
-        ), patch(
-            "gate_controller.worker.Thread", WorkerThread
-        ), patch(
-            "gate_controller.worker.current_thread_is_main", return_value=False
-        ), patch(
-            "gate_controller.worker.sleep", side_effect=KeyboardInterrupt
-        ):
-            run_worker(
-                Path(directory), lambda *_: None,
-                snapshot_sampling=type("Config", (), {"enabled": True})(),
-            )
-
-        primary = ((Path("primary-ftp.jpg"),), None)
-        augmentation = ((Path("optional-snapshot.jpg"),), None)
-        configured["emits"][0](primary)
-        configured["emits"][1](augmentation)
-
-        self.assertIn(("evicting", primary), configured["queue_calls"])
-        self.assertIn(("non_evicting", augmentation), configured["queue_calls"])
-        self.assertNotIn(("evicting", augmentation), configured["queue_calls"])
-
-    def test_disabled_sampling_cleans_and_ignores_private_files_without_a_thread(self):
+    def test_disabled_sampling_does_not_touch_private_files_or_start_a_thread(self):
         configured = {}
         lifecycle = []
 
@@ -947,91 +1382,8 @@ class WorkerTests(unittest.TestCase):
         self.assertEqual(lifecycle.count("sampler_init"), 1)
         self.assertEqual(lifecycle.count("sampler_close"), 1)
         self.assertNotIn("thread_start:ReolinkSnapshotSampler", lifecycle)
-        self.assertEqual(configured["handler"]["ignored_roots"], (output_directory,))
+        self.assertEqual(configured["handler"]["ignored_roots"], ())
         self.assertIsNone(configured["handler"]["on_first_completed"])
-
-    def test_deferred_snapshot_cleanup_waits_for_an_overlong_processor(self):
-        lifecycle = []
-
-        class Collector:
-            def __init__(self, emit, **kwargs):
-                pass
-
-            def add(self, path, received_at=None):
-                return True
-
-            def flush_due(self):
-                return False
-
-        class Handler:
-            def __init__(self, collector, **kwargs):
-                pass
-
-            def retry_pending(self):
-                return 0
-
-            def schedule_candidate(self, *args):
-                pass
-
-        class Sampler:
-            output_directory = Path("private-snapshots")
-
-            def __init__(self, config, add_candidate):
-                pass
-
-            def request(self, received_at=None):
-                return True
-
-            def run_forever(self, stop_event):
-                pass
-
-            def close(self):
-                lifecycle.append("sampler_close")
-
-        class WorkerThread:
-            def __init__(self, *args, **kwargs):
-                self.target = kwargs.get("target", args[0] if args else None)
-                self.args = kwargs.get("args", ())
-                self.name = kwargs.get("name")
-
-            def start(self):
-                lifecycle.append(f"thread_start:{self.name}")
-                if self.name == "ReolinkSnapshotCleanup":
-                    self.target(*self.args)
-
-            def join(self, timeout=None):
-                lifecycle.append(f"thread_join:{self.name}:{timeout}")
-
-            def is_alive(self):
-                return self.name == "GateBurstProcessor"
-
-        with tempfile.TemporaryDirectory() as directory, patch(
-            "gate_controller.worker.BurstCollector", Collector
-        ), patch(
-            "gate_controller.worker.CompletedImageHandler", Handler
-        ), patch(
-            "gate_controller.worker.ReolinkSnapshotSampler", Sampler
-        ), patch(
-            "gate_controller.worker.Observer", return_value=PassiveObserver()
-        ), patch(
-            "gate_controller.worker.Thread", WorkerThread
-        ), patch(
-            "gate_controller.worker.current_thread_is_main", return_value=False
-        ), patch(
-            "gate_controller.worker.sleep", side_effect=KeyboardInterrupt
-        ), self.assertLogs("gate_controller.worker", level="WARNING") as logs:
-            run_worker(
-                Path(directory), lambda *_: None,
-                snapshot_sampling=type("Config", (), {"enabled": True})(),
-            )
-
-        self.assertIn("outcome=cleanup_deferred", "\n".join(logs.output))
-        self.assertIn("thread_start:ReolinkSnapshotCleanup", lifecycle)
-        self.assertLess(
-            lifecycle.index("thread_join:GateBurstProcessor:None"),
-            lifecycle.index("sampler_close"),
-        )
-        self.assertEqual(lifecycle.count("sampler_close"), 1)
 
     def test_queue_coalesced_callback_receives_exact_collector_boundaries(self):
         configured = {}


### PR DESCRIPTION
## Summary

- start recognition immediately from the camera FTP trigger while bounded Reolink snapshots augment the same visit
- enforce a single durable recognition/actuation claim across trigger and snapshot candidates
- make terminal cleanup exception-safe so temporary snapshots and progressive state cannot be stranded
- preserve anchored snapshot evidence through the durable outbox for thumbnails and review
- emit augmentation success/failure telemetry and flush pending work cleanly during shutdown

## Safety

- snapshot-only and uncorrelated augmentation cannot authorize or actuate the gate
- no relay, GPIO, coordinator, or diagnostic gate actuation was added or used during validation
- the camera baseline remains unchanged

## Verification

- independent review found no issues in the final patch
- focused recognition suite: 157/157 passed
- full suite: 614 passed, 3 skipped; 5 environment-only loopback socket-bind errors in the local sandbox and no behavioral assertion failures
- compile and diff checks passed
