### PR TITLE
Report deployed controller release

### DIFF
--- a/gate_controller/__main__.py
+++ b/gate_controller/__main__.py
@@ -3,6 +3,7 @@ import ipaddress
 import logging
 import math
 import os
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -38,6 +39,8 @@ from .runtime import require_python_version
 MIN_QUIET_WINDOW_SECONDS = 0.1
 MAX_QUIET_WINDOW_SECONDS = 2.0
 DEFAULT_QUIET_WINDOW_SECONDS = 0.2
+MANAGED_RELEASES_ROOT = Path("/opt/gate-controller-deploy/releases")
+MANAGED_RELEASE_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 
 
 def main() -> None:
@@ -340,7 +343,8 @@ def image_runtime_limits(environment) -> tuple[int, int]:
 def _controller_status(store, prompt_player, latest_image, authorised=None, *, relay=None,
                        camera_directory=None, camera_stale_seconds: float = 60.0,
                        media_capabilities_path=Path("/run/gate-media/capabilities.json"),
-                       clock=None) -> dict:
+                       module_path=Path(__file__),
+                       managed_releases_root=MANAGED_RELEASES_ROOT, clock=None) -> dict:
     now = (clock or (lambda: datetime.now(timezone.utc)))()
     camera_upload_recent = _camera_is_fresh(
         latest_image.get("received_at"), now, camera_stale_seconds
@@ -361,9 +365,33 @@ def _controller_status(store, prompt_player, latest_image, authorised=None, *, r
         "relay": _relay_status(relay),
         "media": read_media_capabilities(media_capabilities_path),
     }
+    release_sha = _managed_release_sha(
+        module_path, releases_root=managed_releases_root
+    )
+    if release_sha is not None:
+        status["software"] = {"release_sha": release_sha}
     if authorised is not None:
         status["authorisation"] = authorised.status()
     return status
+
+
+def _managed_release_sha(
+    module_path: Path, *, releases_root=MANAGED_RELEASES_ROOT
+) -> str | None:
+    try:
+        resolved_module = Path(module_path).resolve(strict=True)
+        resolved_releases = Path(releases_root).resolve(strict=True)
+        relative_module = resolved_module.relative_to(resolved_releases)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if len(relative_module.parts) < 2:
+        return None
+    release_sha = relative_module.parts[0]
+    release = resolved_releases / release_sha
+    if (MANAGED_RELEASE_SHA_PATTERN.fullmatch(release_sha) is None
+            or release.is_symlink() or not release.is_dir()):
+        return None
+    return release_sha
 
 
 def _relay_status(relay) -> dict:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -425,6 +425,80 @@ class MainConfigurationTests(unittest.TestCase):
         self.assertEqual("gateway_unhealthy", status["media"]["video"]["reason"])
         self.assertEqual(0, status["queue_depth"])
 
+    def test_managed_release_sha_resolves_the_module_path_to_its_release_ancestor(self):
+        release_sha = "0123456789abcdef0123456789abcdef01234567"
+        root = Path(self.create_store().path).parent
+        module = root / "releases" / release_sha / "gate_controller" / "__main__.py"
+        module.parent.mkdir(parents=True)
+        module.touch()
+        current = root / "current"
+        current.symlink_to(module.parent.parent, target_is_directory=True)
+
+        self.assertEqual(
+            release_sha,
+            gate_main._managed_release_sha(
+                current / "gate_controller" / "__main__.py",
+                releases_root=root / "releases",
+            ),
+        )
+
+    def test_managed_release_sha_rejects_a_canonical_sha_outside_the_releases_root(self):
+        release_sha = "0123456789abcdef0123456789abcdef01234567"
+        root = Path(self.create_store().path).parent
+        releases_root = root / "managed" / "releases"
+        releases_root.mkdir(parents=True)
+        module = root / "unmanaged" / release_sha / "gate_controller" / "__main__.py"
+        module.parent.mkdir(parents=True)
+        module.touch()
+
+        self.assertIsNone(
+            gate_main._managed_release_sha(module, releases_root=releases_root)
+        )
+
+    def test_managed_release_sha_rejects_noncanonical_or_unmanaged_paths(self):
+        root = Path(self.create_store().path).parent
+        invalid_ancestors = (
+            "0123456789ABCDEF0123456789ABCDEF01234567",
+            "0123456789abcdef0123456789abcdef0123456",
+            "0123456789abcdef0123456789abcdef012345678",
+            "g123456789abcdef0123456789abcdef01234567",
+            "checkout",
+        )
+
+        for ancestor in invalid_ancestors:
+            with self.subTest(ancestor=ancestor):
+                module = root / ancestor / "gate_controller" / "__main__.py"
+                module.parent.mkdir(parents=True)
+                module.touch()
+                self.assertIsNone(
+                    gate_main._managed_release_sha(
+                        module, releases_root=root / "releases"
+                    )
+                )
+
+    def test_controller_status_includes_only_a_valid_nested_software_release(self):
+        store = self.create_store()
+        release_sha = "fedcba9876543210fedcba9876543210fedcba98"
+        module = (
+            store.path.parent / "releases" / release_sha
+            / "gate_controller" / "__main__.py"
+        )
+        module.parent.mkdir(parents=True)
+        module.touch()
+        prompt = type("Prompt", (), {"available": False})()
+
+        managed = gate_main._controller_status(
+            store, prompt, {}, module_path=module,
+            managed_releases_root=store.path.parent / "releases",
+        )
+        unmanaged = gate_main._controller_status(
+            store, prompt, {}, module_path=store.path.parent / "checkout" / "__main__.py",
+            managed_releases_root=store.path.parent / "releases",
+        )
+
+        self.assertEqual({"release_sha": release_sha}, managed["software"])
+        self.assertNotIn("software", unmanaged)
+
     def test_outbox_url_requires_a_nonempty_bearer_token(self):
         store = self.create_store()
 


### PR DESCRIPTION
## Summary
- report the canonical managed release SHA in controller heartbeats
- accept only releases beneath `/opt/gate-controller-deploy/releases/<sha>`
- omit software metadata for unmanaged or malformed paths

## Verification
- strict TDD for managed, unmanaged, malformed, and symlink-resolved paths
- `tests.test_main`: 32 passed
- independent review completed; release-root trust issue fixed
- compile and diff checks passed

No gate actuation, camera, recognition, media, GPIO, relay, or production configuration behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Controller status now reports the software release identifier when a valid managed release is detected.
  * Release identifiers are validated for format and location to ensure only trusted release information is reported.

* **Bug Fixes**
  * Invalid, inaccessible, symbolic-link, or unmanaged release paths are safely rejected without disrupting status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->