### PR TITLE
Split OCR failure causes and widen first-attempt read window

### DIFF
--- a/gate_controller/ocr.py
+++ b/gate_controller/ocr.py
@@ -1,3 +1,5 @@
+import logging
+import re
 from collections.abc import Mapping
 from math import isfinite
 from pathlib import Path
@@ -10,9 +12,121 @@ from .models import PlateObservation
 DEFAULT_ENDPOINT = "https://api.platerecognizer.com/v1/plate-reader/"
 DEFAULT_TIMEOUT = (1, 2)
 
+# Bounded, operator-facing labels describing *why* an OCR attempt failed. They
+# separate network problems from API problems without ever carrying a response
+# body, a credential, or a filesystem path.
+CAUSE_CONNECT_TIMEOUT = "connect_timeout"
+CAUSE_READ_TIMEOUT = "read_timeout"
+CAUSE_REQUEST_TIMEOUT = "request_timeout"
+CAUSE_TLS_ERROR = "tls_error"
+CAUSE_CONNECTION_ERROR = "connection_error"
+CAUSE_REQUEST_ERROR = "request_error"
+CAUSE_INVALID_JSON = "invalid_json"
+CAUSE_INVALID_PAYLOAD = "invalid_payload"
+CAUSE_INVALID_RESULTS = "invalid_results"
+CAUSE_INVALID_RESULT_ENTRY = "invalid_result_entry"
+CAUSE_NO_USABLE_PLATE = "no_usable_plate"
+CAUSE_INVALID_CONFIDENCE = "invalid_confidence"
+CAUSE_INVALID_RESPONSE = "invalid_response"
+CAUSE_INVALID_HTTP_STATUS = "http_invalid_status"
+CAUSE_REQUEST_ABANDONED = "request_abandoned"
+CAUSE_CLIENT_CLOSED = "client_closed"
+CAUSE_UNCLASSIFIED = "unclassified"
+
+_FAILURE_CAUSE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+_LOGGER = logging.getLogger(__name__)
+
+
+def bounded_failure_cause(value: object) -> str:
+    """Return a safe short token, rejecting anything unbounded or unexpected."""
+    if isinstance(value, str) and _FAILURE_CAUSE.fullmatch(value):
+        return value
+    return CAUSE_UNCLASSIFIED
+
+
+def http_failure_cause(status: object) -> str:
+    """Label a non-2xx response by status code only, never by its body."""
+    if isinstance(status, bool) or not isinstance(status, int):
+        return CAUSE_INVALID_HTTP_STATUS
+    if not 100 <= status <= 599:
+        return CAUSE_INVALID_HTTP_STATUS
+    return f"http_{status}"
+
+
+def classify_failure_cause(error: BaseException) -> str:
+    """Classify an OCR failure into a bounded cause label."""
+    declared = getattr(error, "failure_cause", None)
+    if isinstance(declared, str) and _FAILURE_CAUSE.fullmatch(declared):
+        return declared
+    return _classify_transport_error(error)
+
+
+def _classify_transport_error(error: BaseException) -> str:
+    exceptions = _requests_exceptions()
+    if exceptions is not None:
+        # Most specific first: ConnectTimeout subclasses both ConnectionError
+        # and Timeout, and SSLError subclasses ConnectionError.
+        for name, cause in (
+            ("ConnectTimeout", CAUSE_CONNECT_TIMEOUT),
+            ("ReadTimeout", CAUSE_READ_TIMEOUT),
+            ("Timeout", CAUSE_REQUEST_TIMEOUT),
+            ("SSLError", CAUSE_TLS_ERROR),
+            ("ConnectionError", CAUSE_CONNECTION_ERROR),
+            ("RequestException", CAUSE_REQUEST_ERROR),
+        ):
+            candidate = getattr(exceptions, name, None)
+            if isinstance(candidate, type) and isinstance(error, candidate):
+                return cause
+    if isinstance(error, TimeoutError):
+        return CAUSE_REQUEST_TIMEOUT
+    if isinstance(error, OSError):
+        return CAUSE_CONNECTION_ERROR
+    return CAUSE_UNCLASSIFIED
+
+
+def _requests_exceptions():
+    try:
+        from requests import exceptions
+    except Exception:
+        return None
+    return exceptions
+
+
+def _log_failure(cause: str) -> None:
+    """Journal the bounded cause only; never a body, path, or credential."""
+    try:
+        _LOGGER.warning(
+            "gate_ocr stage=attempt_failed cause=%s", bounded_failure_cause(cause)
+        )
+    except Exception:
+        return
+
+
+def _log_transport_failure(error: BaseException) -> None:
+    """Journal a transport failure without ever masking the original error."""
+    try:
+        _log_failure(classify_failure_cause(error))
+    except Exception:
+        return
+
+
+def _response_error(message: str, cause: str) -> "OcrResponseError":
+    _log_failure(cause)
+    return OcrResponseError(message, cause)
+
+
+def _closed_client_error() -> RuntimeError:
+    error = RuntimeError("OCR client is closed")
+    error.failure_cause = CAUSE_CLIENT_CLOSED
+    return error
+
 
 class OcrResponseError(RuntimeError):
     """The OCR service returned a response that cannot be trusted."""
+
+    def __init__(self, message: str, failure_cause: str = CAUSE_INVALID_RESPONSE) -> None:
+        super().__init__(message)
+        self.failure_cause = bounded_failure_cause(failure_cause)
 
 
 class PlateRecognizerClient:
@@ -29,7 +143,7 @@ class PlateRecognizerClient:
     def recognise(self, path: Path, timeout: tuple[float, float] | None = None) -> PlateObservation:
         with self._session_lock:
             if self._closed:
-                raise RuntimeError("OCR client is closed")
+                raise _closed_client_error()
             generation = self._session_generation
             session = self._session
         if session is None:
@@ -39,10 +153,12 @@ class PlateRecognizerClient:
             with self._session_lock:
                 if self._closed:
                     discard_created = True
-                    error = RuntimeError("OCR client is closed")
+                    error = _closed_client_error()
                 elif generation != self._session_generation:
                     discard_created = True
-                    error = OcrResponseError("OCR request was abandoned")
+                    error = OcrResponseError(
+                        "OCR request was abandoned", CAUSE_REQUEST_ABANDONED
+                    )
                 elif self._session is None:
                     self._session = created
                     session = created
@@ -55,41 +171,64 @@ class PlateRecognizerClient:
                 raise error
         with self._session_lock:
             if self._closed:
-                raise RuntimeError("OCR client is closed")
+                raise _closed_client_error()
             if generation != self._session_generation:
-                raise OcrResponseError("OCR request was abandoned")
+                raise OcrResponseError(
+                    "OCR request was abandoned", CAUSE_REQUEST_ABANDONED
+                )
         with path.open("rb") as image:
-            response = session.post(
-                self._endpoint,
-                data={"regions": "ie"},
-                files={"upload": (path.name, image, "image/jpeg")},
-                headers={"Authorization": f"Token {self._token}"},
-                timeout=timeout or self._timeout,
-            )
+            try:
+                response = session.post(
+                    self._endpoint,
+                    data={"regions": "ie"},
+                    files={"upload": (path.name, image, "image/jpeg")},
+                    headers={"Authorization": f"Token {self._token}"},
+                    timeout=timeout or self._timeout,
+                )
+            except Exception as error:
+                # Classify and journal the transport failure, then let the
+                # original exception propagate unchanged.
+                _log_transport_failure(error)
+                raise
 
         if not 200 <= response.status_code < 300:
-            raise OcrResponseError(f"OCR service returned HTTP {response.status_code}")
+            raise _response_error(
+                f"OCR service returned HTTP {response.status_code}",
+                http_failure_cause(response.status_code),
+            )
         try:
             payload = response.json()
         except Exception as error:
-            raise OcrResponseError("OCR service returned invalid JSON") from error
+            raise _response_error(
+                "OCR service returned invalid JSON", CAUSE_INVALID_JSON
+            ) from error
         if not isinstance(payload, Mapping):
-            raise OcrResponseError("OCR service returned a non-object payload")
+            raise _response_error(
+                "OCR service returned a non-object payload", CAUSE_INVALID_PAYLOAD
+            )
         results = payload.get("results")
         if not isinstance(results, list):
-            raise OcrResponseError("OCR service response has invalid results")
+            raise _response_error(
+                "OCR service response has invalid results", CAUSE_INVALID_RESULTS
+            )
         if not results:
             return PlateObservation(plate=None, confidence=0.0)
         first_result = results[0]
         if not isinstance(first_result, Mapping):
-            raise OcrResponseError("OCR service response has invalid result")
+            raise _response_error(
+                "OCR service response has invalid result", CAUSE_INVALID_RESULT_ENTRY
+            )
         plate = first_result.get("plate")
         score = first_result.get("score")
         if not isinstance(plate, str) or not normalise_plate(plate):
-            raise OcrResponseError("OCR service response has no usable plate")
+            raise _response_error(
+                "OCR service response has no usable plate", CAUSE_NO_USABLE_PLATE
+            )
         if (isinstance(score, bool) or not isinstance(score, (int, float))
                 or not isfinite(score) or not 0 <= score <= 1):
-            raise OcrResponseError("OCR service response has invalid confidence")
+            raise _response_error(
+                "OCR service response has invalid confidence", CAUSE_INVALID_CONFIDENCE
+            )
         return PlateObservation(
             plate=normalise_plate(plate), confidence=float(score),
             make=_optional_string(first_result.get("vehicle", {}), "make"),

--- a/gate_controller/processor.py
+++ b/gate_controller/processor.py
@@ -17,6 +17,7 @@ from .actuation import ActuationCoordinator
 from .images import measure_frame_quality
 from .matching import decide_access, normalise_plate
 from .models import GateEvent, ProcessingResult
+from .ocr import classify_failure_cause
 from .telemetry import (
     OcrAttemptTelemetry, ProcessingTrace, TriggerTelemetry,
     ftp_fallback_trigger,
@@ -25,6 +26,13 @@ from .telemetry import (
 
 MAX_OCR_FRAMES = 3
 DEFAULT_ACTIVATION_GUARD_SECONDS = 0.1
+OCR_CONNECT_TIMEOUT_SECONDS = 1.0
+OCR_READ_TIMEOUT_SECONDS = 2.0
+# The first frame is the full-resolution capture and fallback frames are often
+# unavailable, so the opening attempt may spend more of the decision budget
+# waiting for a slow API. The decision deadline still bounds the whole event.
+OCR_FIRST_ATTEMPT_READ_TIMEOUT_SECONDS = 2.8
+MIN_OCR_TIMEOUT_SECONDS = 0.1
 FINAL_INHIBITION_REASONS = frozenset({
     "stale_burst", "authorisation_error", "authorisation_revoked",
     "decision_timeout", "processor_closed",
@@ -163,7 +171,9 @@ class GateProcessor:
                 ocr_started = True
 
             try:
-                observation = self._recognise(path, deadline, mark_ocr_start)
+                observation = self._recognise(
+                    path, deadline, mark_ocr_start, first_attempt=sequence == 0,
+                )
             except _OcrBusy:
                 trace.add_ocr_rejection(OcrAttemptTelemetry(
                     frame_sequence=sequence,
@@ -179,11 +189,15 @@ class GateProcessor:
                     ))
                 timed_out = True
                 break
-            except Exception:
+            except Exception as error:
+                # The event-level reason stays "ocr_error"; only the recorded
+                # cause distinguishes a network fault from an API fault.
+                failure_cause = _safe_failure_cause(error)
                 if ocr_started:
                     trace.add_ocr_attempt(OcrAttemptTelemetry(
                         frame_sequence=sequence,
                         status="ocr_error",
+                        failure_cause=failure_cause,
                     ))
                 ocr_failure_reason = "ocr_error"
                 continue
@@ -390,15 +404,23 @@ class GateProcessor:
             payload["_awaiting_telemetry"] = True
         return payload
 
-    def _recognise(self, path: Path, deadline: float, on_start=None):
+    def _recognise(self, path: Path, deadline: float, on_start=None, *,
+                   first_attempt: bool = False):
         remaining = deadline - self._decision_clock()
         if remaining <= 0:
             raise _OcrDeadlineExceeded("OCR request exceeded the decision deadline")
         operation = lambda: self._recognise_call(path)
         if not self._recognizer_accepts_timeout:
             return self._run_ocr_bounded(operation, deadline, on_start)
-        connect = min(1.0, max(0.1, remaining / 3))
-        read = min(2.0, max(0.1, remaining - connect))
+        connect = min(
+            OCR_CONNECT_TIMEOUT_SECONDS,
+            max(MIN_OCR_TIMEOUT_SECONDS, remaining / 3),
+        )
+        read_cap = (
+            OCR_FIRST_ATTEMPT_READ_TIMEOUT_SECONDS if first_attempt
+            else OCR_READ_TIMEOUT_SECONDS
+        )
+        read = min(read_cap, max(MIN_OCR_TIMEOUT_SECONDS, remaining - connect))
         operation = lambda: self._recognise_call(path, timeout=(connect, read))
         return self._run_ocr_bounded(operation, deadline, on_start)
 
@@ -691,17 +713,41 @@ def _accepts_keyword(callable_object, keyword: str) -> bool:
     )
 
 
+def _safe_failure_cause(error: BaseException) -> str | None:
+    """Classify an OCR failure without ever disturbing recognition."""
+    try:
+        return classify_failure_cause(error)
+    except Exception:
+        return None
+
+
+def _recorded_failure_causes(telemetry) -> tuple:
+    try:
+        return tuple(
+            getattr(attempt, "failure_cause", None)
+            for attempt in telemetry.ocr_attempts
+        )
+    except Exception:
+        return ()
+
+
 def _log_completed_trace(telemetry) -> None:
     try:
         wire = telemetry.to_wire()
-        attempts = [
-            {
+        # failure_cause is journal-only: it is absent from the wire payload
+        # because the ingest contract rejects unknown ocr_attempts keys.
+        causes = _recorded_failure_causes(telemetry)
+        attempts = []
+        for index, attempt in enumerate(wire.get("ocr_attempts", ())):
+            entry = {
                 "frame_sequence": attempt.get("frame_sequence"),
                 "duration_ms": attempt.get("duration_ms"),
                 "status": attempt.get("status"),
             }
-            for attempt in wire.get("ocr_attempts", ())
-        ]
+            cause = causes[index] if index < len(causes) else None
+            if cause is not None:
+                entry["failure_cause"] = cause
+            attempts.append(entry)
         logging.getLogger(__name__).info(
             "gate_pipeline stage=processing_finished trace_id=%s outcome=%s reason=%s "
             "relay_outcome=%s durations=%s timestamps=%s ocr_attempts=%s",

--- a/gate_controller/telemetry.py
+++ b/gate_controller/telemetry.py
@@ -21,6 +21,7 @@ MAX_UPSTREAM_INTERVAL_SECONDS = MAX_DURATION_MS / 1_000
 MAX_CLOCK_SKEW_SECONDS = 0.1
 
 _TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_FAILURE_CAUSE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
 _SHA256 = re.compile(r"^[a-f0-9]{64}$")
 _TRIGGER_EVENT_TYPES = frozenset({
     "line_crossing", "vehicle", "manual_test", "other", "unverified",
@@ -75,6 +76,12 @@ def _optional_string(value: object | None) -> str | None:
     return value[:MAX_STRING_LENGTH]
 
 
+def _optional_failure_cause(value: object | None) -> str | None:
+    if isinstance(value, str) and _FAILURE_CAUSE.fullmatch(value):
+        return value
+    return None
+
+
 def _trace_id(value: object) -> str:
     if isinstance(value, str):
         try:
@@ -127,8 +134,20 @@ class OcrAttemptTelemetry:
     confidence: float | None = None
     make: str | None = None
     colour: str | None = None
+    #: Bounded reason this attempt failed. Journal-only: the Cloudflare ingest
+    #: contract validates ``ocr_attempts`` against a strict key allowlist and
+    #: rejects the whole event for any unknown key, so this is deliberately
+    #: absent from :meth:`to_wire`.
+    failure_cause: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "failure_cause", _optional_failure_cause(self.failure_cause)
+        )
 
     def to_wire(self) -> dict[str, object]:
+        # Wire keys are frozen by the ingest contract. Do not add fields here
+        # without first extending the Worker's OCR_ATTEMPT_KEYS allowlist.
         return {
             "frame_sequence": _rounded_int(self.frame_sequence, 0, MAX_ITEMS - 1, 0),
             "duration_ms": _duration(self.duration_ms) or 0,

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -5,14 +5,22 @@ from pathlib import Path
 from threading import Event, Thread
 from unittest.mock import patch
 
-from gate_controller.ocr import OcrResponseError, PlateRecognizerClient
+import gate_controller.ocr as ocr_module
+from gate_controller.ocr import (
+    OcrResponseError,
+    PlateRecognizerClient,
+    bounded_failure_cause,
+    classify_failure_cause,
+    http_failure_cause,
+)
 
 
 class FakeResponse:
-    def __init__(self, status_code=200, payload=None, json_error=None):
+    def __init__(self, status_code=200, payload=None, json_error=None, text=""):
         self.status_code = status_code
         self._payload = payload
         self._json_error = json_error
+        self.text = text
 
     def json(self):
         if self._json_error:
@@ -229,6 +237,172 @@ class OcrClientTests(unittest.TestCase):
 
                 with self.assertRaisesRegex(OcrResponseError, "confidence"):
                     client.recognise(self.path)
+
+
+class OcrFailureCauseTests(unittest.TestCase):
+    """Each rejected response is labelled with a precise, bounded cause."""
+
+    def setUp(self):
+        self.image = tempfile.NamedTemporaryFile(suffix=".jpg", delete=False)
+        self.image.write(b"test image")
+        self.image.close()
+        self.path = Path(self.image.name)
+
+    def tearDown(self):
+        self.path.unlink(missing_ok=True)
+
+    def _cause_for(self, response):
+        client = PlateRecognizerClient("token", session=FakeSession(response=response))
+        with self.assertRaises(OcrResponseError) as caught:
+            client.recognise(self.path)
+        return caught.exception.failure_cause
+
+    def test_labels_each_rejected_response_shape_with_its_own_cause(self):
+        cases = (
+            (FakeResponse(status_code=429), "http_429"),
+            (FakeResponse(status_code=503), "http_503"),
+            (FakeResponse(status_code=500), "http_500"),
+            (FakeResponse(json_error=ValueError("no json")), "invalid_json"),
+            (FakeResponse(payload=["not", "a", "map"]), "invalid_payload"),
+            (FakeResponse(payload={"results": {}}), "invalid_results"),
+            (FakeResponse(payload={"results": ["nope"]}), "invalid_result_entry"),
+            (FakeResponse(payload={"results": [{"plate": "!!", "score": 0.9}]}),
+             "no_usable_plate"),
+            (FakeResponse(payload={"results": [{"plate": "12D3456", "score": 2}]}),
+             "invalid_confidence"),
+        )
+        for response, expected in cases:
+            with self.subTest(cause=expected):
+                self.assertEqual(self._cause_for(response), expected)
+
+    def test_reports_the_status_code_only_for_every_non_success_response(self):
+        for status in (400, 401, 404, 429, 500, 502, 503):
+            with self.subTest(status=status):
+                cause = self._cause_for(FakeResponse(status_code=status))
+                self.assertEqual(cause, f"http_{status}")
+
+    def test_bounds_implausible_status_codes_instead_of_echoing_them(self):
+        for status in (None, True, "429", 99, 600, 1_000_000, 2.5):
+            with self.subTest(status=status):
+                self.assertEqual(http_failure_cause(status), "http_invalid_status")
+
+    def test_rejects_unbounded_or_malformed_cause_labels(self):
+        for value in (None, 42, "", "Has Spaces", "UPPER", "a" * 33, "9leading"):
+            with self.subTest(value=value):
+                self.assertEqual(bounded_failure_cause(value), "unclassified")
+        self.assertEqual(bounded_failure_cause("read_timeout"), "read_timeout")
+        self.assertEqual(bounded_failure_cause("http_429"), "http_429")
+
+    def test_labels_an_abandoned_request_without_changing_its_category(self):
+        client = PlateRecognizerClient("token")
+
+        def create_session():
+            client.abandon_in_flight()
+            return FakeSession(response=FakeResponse(payload={"results": []}))
+
+        with patch.object(client, "_create_session", side_effect=create_session):
+            with self.assertRaises(OcrResponseError) as caught:
+                client.recognise(self.path)
+
+        self.assertEqual(caught.exception.failure_cause, "request_abandoned")
+
+    def test_labels_a_closed_client_without_changing_its_category(self):
+        client = PlateRecognizerClient("token", session=FakeSession())
+        client.close()
+
+        with self.assertRaises(RuntimeError) as caught:
+            client.recognise(self.path)
+
+        self.assertNotIsInstance(caught.exception, OcrResponseError)
+        self.assertEqual(classify_failure_cause(caught.exception), "client_closed")
+
+    def test_separates_network_faults_from_api_faults(self):
+        from requests import exceptions
+
+        cases = (
+            (exceptions.ConnectTimeout("connect"), "connect_timeout"),
+            (exceptions.ReadTimeout("read"), "read_timeout"),
+            (exceptions.Timeout("timeout"), "request_timeout"),
+            (exceptions.SSLError("tls"), "tls_error"),
+            (exceptions.ProxyError("proxy"), "connection_error"),
+            (exceptions.ConnectionError("connect"), "connection_error"),
+            (exceptions.TooManyRedirects("redirects"), "request_error"),
+            (TimeoutError("plain"), "request_timeout"),
+            (ConnectionRefusedError("refused"), "connection_error"),
+            (ValueError("unrelated"), "unclassified"),
+        )
+        for error, expected in cases:
+            with self.subTest(cause=expected):
+                self.assertEqual(classify_failure_cause(error), expected)
+
+    def test_transport_failures_propagate_unchanged_after_being_labelled(self):
+        from requests import exceptions
+
+        error = exceptions.ReadTimeout("upstream read timed out")
+        client = PlateRecognizerClient("token", session=FakeSession(error=error))
+
+        with self.assertLogs("gate_controller.ocr", level="WARNING") as logs:
+            with self.assertRaises(exceptions.ReadTimeout) as caught:
+                client.recognise(self.path)
+
+        self.assertIs(caught.exception, error)
+        self.assertIn("cause=read_timeout", "\n".join(logs.output))
+
+    def test_a_failing_classifier_never_masks_the_original_transport_error(self):
+        from requests import exceptions
+
+        error = exceptions.ConnectTimeout("unreachable")
+        client = PlateRecognizerClient("token", session=FakeSession(error=error))
+
+        def explode(_error):
+            raise RuntimeError("classifier unavailable")
+
+        with patch.object(ocr_module, "classify_failure_cause", explode):
+            with self.assertRaises(exceptions.ConnectTimeout) as caught:
+                client.recognise(self.path)
+
+        self.assertIs(caught.exception, error)
+
+    def test_journals_the_cause_without_the_response_body_or_credentials(self):
+        secret = "tok_live_abcdef0123456789"
+        body = "PLATE 12D3456 owner Jane Doe SENSITIVE_BODY_MARKER"
+        client = PlateRecognizerClient(
+            secret,
+            session=FakeSession(response=FakeResponse(
+                status_code=429, payload={"error": body}, text=body,
+            )),
+        )
+
+        with self.assertLogs("gate_controller.ocr", level="WARNING") as logs:
+            with self.assertRaises(OcrResponseError):
+                client.recognise(self.path)
+
+        combined = "\n".join(logs.output)
+        self.assertIn("cause=http_429", combined)
+        self.assertNotIn(secret, combined)
+        self.assertNotIn("SENSITIVE_BODY_MARKER", combined)
+        self.assertNotIn("12D3456", combined)
+        self.assertNotIn(str(self.path), combined)
+        self.assertNotIn("platerecognizer.com", combined)
+
+    def test_never_journals_a_credential_for_any_rejected_response(self):
+        secret = "tok_live_abcdef0123456789"
+        responses = (
+            FakeResponse(status_code=500, text=secret),
+            FakeResponse(json_error=ValueError(secret)),
+            FakeResponse(payload={"results": [{"plate": "!!", "score": 0.9}]}),
+        )
+        for response in responses:
+            with self.subTest(status=response.status_code):
+                client = PlateRecognizerClient(
+                    secret, session=FakeSession(response=response)
+                )
+                with self.assertLogs("gate_controller.ocr", level="WARNING") as logs:
+                    with self.assertRaises(OcrResponseError):
+                        client.recognise(self.path)
+                combined = "\n".join(logs.output)
+                self.assertNotIn(secret, combined)
+                self.assertRegex(combined, r"cause=[a-z][a-z0-9_]{0,31}$")
 
 
 if __name__ == "__main__":

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -9,10 +9,12 @@ from threading import Event, Lock, Thread
 from time import monotonic
 from unittest.mock import patch
 from PIL import Image
+from requests import exceptions as requests_exceptions
 
 import gate_controller.images as image_tools
 import gate_controller.processor as processor_module
 from gate_controller.models import PlateObservation, RelayResult
+from gate_controller.ocr import OcrResponseError
 from gate_controller.outbox import EvidenceSpool, OutboxWorker
 from gate_controller.processor import GateProcessor
 from gate_controller.relay import RelayController
@@ -2323,6 +2325,214 @@ class GateProcessorTests(unittest.TestCase):
 
             self.assertEqual(repaired.reason, "duplicate_event")
             self.assertEqual(store.pending_outbox_count(), 1)
+
+
+class OcrFailureCauseTests(unittest.TestCase):
+    """A denied ocr_error event records *why* the OCR call failed."""
+
+    def _processor(self, store, relay, recognizer, **kwargs):
+        return GateProcessor(
+            recognizer=recognizer,
+            store=store,
+            relay=relay,
+            authorised={"12D3456"},
+            cooldown=timedelta(seconds=20),
+            clock=lambda: datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc),
+            **kwargs,
+        )
+
+    def _jpeg(self, directory: str, name: str, colour: int = 128) -> Path:
+        path = Path(directory) / name
+        Image.new("L", (16, 8), color=colour).save(path, format="JPEG")
+        return path
+
+    def _process_failure(self, directory, error):
+        processor = self._processor(
+            LocalStore(Path(directory) / "gate.db"),
+            RecordingRelay([]),
+            StaticRecognizer(error=error),
+        )
+        return processor.process((self._jpeg(directory, "frame.jpg"),))
+
+    def test_records_the_cause_while_keeping_the_ocr_error_reason(self):
+        cases = (
+            (OcrResponseError("OCR service returned HTTP 429", "http_429"), "http_429"),
+            (OcrResponseError("invalid json", "invalid_json"), "invalid_json"),
+            (OcrResponseError("no usable plate", "no_usable_plate"), "no_usable_plate"),
+            (requests_exceptions.ReadTimeout("slow"), "read_timeout"),
+            (requests_exceptions.ConnectTimeout("unreachable"), "connect_timeout"),
+            (requests_exceptions.ConnectionError("refused"), "connection_error"),
+        )
+        for error, expected in cases:
+            with self.subTest(cause=expected), tempfile.TemporaryDirectory() as directory:
+                result = self._process_failure(directory, error)
+
+                self.assertFalse(result.opened)
+                self.assertEqual(result.reason, "ocr_error")
+                attempt = tuple(result.telemetry.ocr_attempts)[0]
+                self.assertEqual(attempt.status, "ocr_error")
+                self.assertEqual(attempt.failure_cause, expected)
+
+    def test_wire_payload_still_carries_only_the_unchanged_attempt_status(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self._process_failure(
+                directory, OcrResponseError("rate limited", "http_429")
+            )
+
+        wire = result.telemetry.to_wire()
+        self.assertEqual(wire["decision"]["reason"], "ocr_error")
+        self.assertEqual(wire["ocr_attempts"][0]["status"], "ocr_error")
+        self.assertNotIn("failure_cause", wire["ocr_attempts"][0])
+        self.assertEqual(set(wire["ocr_attempts"][0]), {
+            "frame_sequence", "duration_ms", "status", "plate",
+            "confidence", "make", "colour",
+        })
+
+    def test_journal_line_reports_the_cause_without_plates_or_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            frame = self._jpeg(directory, "private-owner-registration.jpg")
+            processor = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay([]),
+                StaticRecognizer(
+                    error=OcrResponseError("rate limited", "http_429")
+                ),
+            )
+
+            with self.assertLogs("gate_controller.processor", level="INFO") as logs:
+                result = processor.process((frame,))
+
+        combined = "\n".join(logs.output)
+        self.assertIn(f"trace_id={result.telemetry.trace_id}", combined)
+        self.assertIn("outcome=denied reason=ocr_error", combined)
+        self.assertIn('"failure_cause":"http_429"', combined)
+        self.assertIn('"status":"ocr_error"', combined)
+        self.assertNotIn(str(frame), combined)
+        self.assertNotIn("rate limited", combined)
+
+    def test_successful_attempts_carry_no_cause(self):
+        with tempfile.TemporaryDirectory() as directory:
+            processor = self._processor(
+                LocalStore(Path(directory) / "gate.db"),
+                RecordingRelay([]),
+                StaticRecognizer(PlateObservation("12D3456", 0.95)),
+            )
+
+            with self.assertLogs("gate_controller.processor", level="INFO") as logs:
+                result = processor.process((self._jpeg(directory, "frame.jpg"),))
+
+        self.assertTrue(result.opened)
+        self.assertIsNone(tuple(result.telemetry.ocr_attempts)[0].failure_cause)
+        self.assertNotIn("failure_cause", "\n".join(logs.output))
+
+    def test_an_unclassifiable_failure_still_denies_with_ocr_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self._process_failure(directory, ValueError("something odd"))
+
+        self.assertEqual(result.reason, "ocr_error")
+        self.assertEqual(
+            tuple(result.telemetry.ocr_attempts)[0].failure_cause, "unclassified"
+        )
+
+    def test_a_failing_classifier_never_breaks_recognition(self):
+        def explode(error):
+            raise RuntimeError("classifier unavailable")
+
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.object(processor_module, "classify_failure_cause", explode):
+                result = self._process_failure(
+                    directory, OcrResponseError("rate limited", "http_429")
+                )
+
+        self.assertFalse(result.opened)
+        self.assertEqual(result.reason, "ocr_error")
+        self.assertIsNone(tuple(result.telemetry.ocr_attempts)[0].failure_cause)
+
+
+class OcrReadWindowTests(unittest.TestCase):
+    """The first frame may spend more of the decision budget on a slow API."""
+
+    class RecordingTimeoutRecognizer:
+        def __init__(self, results):
+            self.results = iter(results)
+            self.timeouts = []
+
+        def recognise(self, path, timeout=None):
+            self.timeouts.append(timeout)
+            result = next(self.results)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    def _processor(self, store, relay, recognizer, **kwargs):
+        return GateProcessor(
+            recognizer=recognizer,
+            store=store,
+            relay=relay,
+            authorised={"12D3456"},
+            clock=lambda: datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc),
+            **kwargs,
+        )
+
+    def _timeouts(self, results, decision_timeout=4.0, frames=3):
+        decision_clock = MutableClock()
+        recognizer = self.RecordingTimeoutRecognizer(results)
+        with tempfile.TemporaryDirectory() as directory:
+            self._processor(
+                LocalStore(Path(directory) / "gate.db"), RecordingRelay([]), recognizer,
+                decision_timeout=decision_timeout, decision_clock=decision_clock,
+            ).process(tuple(Path(f"frame-{index}.jpg") for index in range(frames)))
+        return recognizer.timeouts
+
+    def test_only_the_first_attempt_may_use_the_widened_read_window(self):
+        timeouts = self._timeouts([PlateObservation(None, 0.0)] * 3)
+
+        self.assertEqual(len(timeouts), 3)
+        self.assertEqual(timeouts[0], (1.0, 2.8))
+        self.assertEqual(timeouts[1], (1.0, 2.0))
+        self.assertEqual(timeouts[2], (1.0, 2.0))
+
+    def test_the_widened_window_still_fits_inside_the_decision_budget(self):
+        decision_timeout = 4.0
+        timeouts = self._timeouts(
+            [PlateObservation(None, 0.0)] * 3, decision_timeout=decision_timeout,
+        )
+
+        for connect, read in timeouts:
+            self.assertLessEqual(connect + read, decision_timeout)
+            self.assertGreaterEqual(connect, 0.1)
+            self.assertGreaterEqual(read, 0.1)
+
+    def test_a_retry_after_a_first_attempt_failure_returns_to_the_narrow_cap(self):
+        timeouts = self._timeouts([
+            OcrResponseError("slow upstream", "read_timeout"),
+            PlateObservation(None, 0.0),
+            PlateObservation(None, 0.0),
+        ])
+
+        self.assertEqual(timeouts[0], (1.0, 2.8))
+        self.assertEqual(timeouts[1], (1.0, 2.0))
+
+    def test_a_short_budget_never_exceeds_the_remaining_time(self):
+        for decision_timeout in (0.5, 1.0, 2.0, 3.0):
+            with self.subTest(decision_timeout=decision_timeout):
+                timeouts = self._timeouts(
+                    [PlateObservation(None, 0.0)] * 3,
+                    decision_timeout=decision_timeout,
+                )
+                connect, read = timeouts[0]
+                self.assertLessEqual(read, 2.8)
+                self.assertLessEqual(connect + read, max(decision_timeout, 0.2))
+
+    def test_the_widened_window_only_applies_below_the_hard_read_cap(self):
+        # With a 3s budget the first attempt cannot reach the 2.8s cap, so the
+        # widened window changes nothing for smaller budgets.
+        timeouts = self._timeouts(
+            [PlateObservation(None, 0.0)] * 3, decision_timeout=3.0,
+        )
+
+        self.assertEqual(timeouts[0], (1.0, 2.0))
+        self.assertEqual(timeouts[1], (1.0, 2.0))
 
 
 if __name__ == "__main__":

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -648,5 +648,105 @@ class ProcessingTraceTests(unittest.TestCase):
         })
 
 
+class OcrFailureCauseTelemetryTests(unittest.TestCase):
+    """The cause is recorded locally and deliberately kept off the wire.
+
+    The Cloudflare ingest contract validates ``ocr_attempts`` against a strict
+    key allowlist and rejects the entire event for any unknown key, so adding
+    the cause to ``to_wire`` would drop every OCR event on the floor.
+    """
+
+    WIRE_KEYS = {
+        "frame_sequence", "duration_ms", "status", "plate",
+        "confidence", "make", "colour",
+    }
+
+    def _telemetry(self, *attempts):
+        return EventTelemetry(
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+            stage_durations=StageDurations(),
+            frames=(),
+            ocr_attempts=attempts,
+            decision_outcome="denied",
+            decision_reason="ocr_error",
+            actuation_claim="not_requested",
+            actuation_attempted=False,
+            relay_outcome="not_attempted",
+            outbox_attempt=0,
+            delivery_state="pending",
+        )
+
+    def test_records_the_cause_on_the_attempt_without_widening_the_wire(self):
+        attempt = OcrAttemptTelemetry(
+            frame_sequence=0, duration_ms=1_200, status="ocr_error",
+            failure_cause="read_timeout",
+        )
+
+        self.assertEqual(attempt.failure_cause, "read_timeout")
+        self.assertEqual(set(attempt.to_wire()), self.WIRE_KEYS)
+        self.assertNotIn("failure_cause", attempt.to_wire())
+
+    def test_wire_payload_is_identical_with_and_without_a_recorded_cause(self):
+        without = self._telemetry(
+            OcrAttemptTelemetry(frame_sequence=0, duration_ms=1_200, status="ocr_error")
+        )
+        with_cause = self._telemetry(
+            OcrAttemptTelemetry(
+                frame_sequence=0, duration_ms=1_200, status="ocr_error",
+                failure_cause="http_429",
+            )
+        )
+
+        self.assertEqual(without.to_wire(), with_cause.to_wire())
+        self.assertEqual(
+            with_cause.to_wire()["ocr_attempts"][0]["status"], "ocr_error"
+        )
+
+    def test_wire_attempt_keys_stay_inside_the_ingest_allowlist(self):
+        wire = self._telemetry(
+            OcrAttemptTelemetry(0, 0, "ocr_error", failure_cause="connection_error"),
+            OcrAttemptTelemetry(1, 0, "ocr_timeout"),
+        ).to_wire()
+
+        for attempt in wire["ocr_attempts"]:
+            self.assertEqual(set(attempt), self.WIRE_KEYS)
+            self.assertFalse(
+                {"failure_cause", "cause", "exception", "raw_response", "path"}
+                & set(attempt)
+            )
+
+    def test_discards_unbounded_or_malformed_causes(self):
+        for value in ("", "Has Spaces", "UPPER", "x" * 33, 42, object(), None):
+            with self.subTest(value=value):
+                attempt = OcrAttemptTelemetry(0, 0, "ocr_error", failure_cause=value)
+                self.assertIsNone(attempt.failure_cause)
+
+    def test_positional_construction_stays_compatible(self):
+        attempt = OcrAttemptTelemetry(0, 5, "no_plate", None, 0.0, None, None)
+
+        self.assertIsNone(attempt.failure_cause)
+        self.assertEqual(attempt.status, "no_plate")
+
+    def test_trace_preserves_the_cause_while_timing_the_attempt(self):
+        # anchor, ocr start, ocr end, finish
+        clock = iter((0.0, 0.0, 1.5, 2.0))
+        trace = ProcessingTrace(
+            monotonic_clock=lambda: next(clock),
+            wall_clock=lambda: datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc),
+            trace_id="ae2398aa-7107-44f4-a723-290de0f8c7b2",
+        )
+
+        trace.mark_ocr_start()
+        trace.add_ocr_attempt(OcrAttemptTelemetry(
+            frame_sequence=0, status="ocr_error", failure_cause="connect_timeout",
+        ))
+        telemetry = trace.finish()
+
+        recorded = tuple(telemetry.ocr_attempts)[0]
+        self.assertEqual(recorded.failure_cause, "connect_timeout")
+        self.assertGreater(recorded.duration_ms, 0)
+        self.assertNotIn("failure_cause", telemetry.to_wire()["ocr_attempts"][0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

In the last 24 hours, 10 of 17 real gate events were denied with event reason `ocr_error` — the HTTPS call to Plate Recognizer failed. Nothing recorded **which** failure it was, so an operator could not tell a network problem from an API problem.

Separately, successful OCR calls measure 1.06–1.38s while the per-request read cap is 2.0s. API slowness under load tipped otherwise-recoverable events into `ocr_error`, even though the whole-event decision budget is 4s (`GATE_DECISION_TIMEOUT_SECONDS`).

## 1. Per-attempt failure-cause observability

`PlateRecognizerClient.recognise` now labels every failure with a bounded cause:

| Cause | Meaning |
| --- | --- |
| `connect_timeout` / `read_timeout` / `request_timeout` | Timed out establishing the connection / waiting on the response / unspecified |
| `connection_error` / `tls_error` / `request_error` | Network fault, TLS fault, other transport fault |
| `http_<status>` | Non-2xx response — **status code only**, e.g. `http_429`, `http_503` |
| `invalid_json` / `invalid_payload` / `invalid_results` / `invalid_result_entry` | Response could not be parsed or was the wrong shape |
| `no_usable_plate` / `invalid_confidence` | Response parsed but carried nothing trustworthy |
| `request_abandoned` / `client_closed` | Lifecycle, not a service failure |
| `unclassified` | Anything unrecognised |

**Nothing about the exception flow changes.** `OcrResponseError` stays a `RuntimeError` and simply gains a `failure_cause` attribute; transport exceptions are journalled and then re-raised **unchanged** with a bare `raise`, so they still propagate with their original type and traceback. `processor.py` continues to distinguish `_OcrBusy` / `_OcrDeadlineExceeded` from generic `Exception`, and the event-level reason for the generic branch is still exactly `ocr_error`. Only the recorded *why* is new.

### The cause is journal-only, not a wire field

I checked the Worker ingest validation before touching telemetry, and **the wire field could not be added safely**:

- `worker/contracts/gate-event-ingest/contract.ts` validates each attempt with `assertAllowedKeys(attempt, OCR_ATTEMPT_KEYS, …)`, a strict allowlist of `frame_sequence`, `duration_ms`, `status`, `plate`, `confidence`, `make`, `colour`. Any other key throws.
- `worker/routes/controller.ts` wraps `validateGateEvent` in `try { … } catch { throw new HttpError(400, 'Invalid controller event') }` — so an unknown key rejects **the entire event**, not just the field.
- The Worker's own suite asserts this (`rejects oversized lists, invalid telemetry bounds, unknown keys, and sensitive field names`).

Shipping `failure_cause` on the wire would therefore have caused every OCR-bearing event to 400 and stall in the outbox — a total cloud-observability blackout. So `OcrAttemptTelemetry.failure_cause` is recorded locally and **deliberately excluded from `to_wire()`**, with comments at both the field and `to_wire` pointing at the Worker allowlist. Existing `status` values (`recognized` / `no_plate` / `ocr_error` / `ocr_timeout` / `ocr_busy`) and the event reason `ocr_error` are byte-for-byte unchanged; tests assert the wire payload is identical with and without a recorded cause.

The cause surfaces in two journal places:

- a per-attempt line in `ocr.py`: `gate_ocr stage=attempt_failed cause=http_429` — this still works when the best-effort trace has been disabled;
- the existing trace-correlated line in `processor.py`, e.g. `ocr_attempts=[{"duration_ms":1204,"failure_cause":"read_timeout","frame_sequence":0,"status":"ocr_error"}]`.

Only the bounded token is ever logged — never a response body, a URL, a filesystem path, or the API token. Causes are validated against `^[a-z][a-z0-9_]{0,31}$`, and implausible status codes collapse to `http_invalid_status` rather than being echoed.

**Fail-safe throughout**, per the existing `_BestEffortTrace` pattern: classification failure returns `None` instead of propagating, the `ocr.py` journal helper swallows its own errors, and a classifier that raises can never mask the original transport exception. Tests cover all three.

## 2. First attempt gets more of the decision budget

`_recognise` previously computed `read = min(2.0, …)` for every attempt. The first attempt of an event (frame sequence 0) may now use up to **2.8s** of read timeout; later attempts keep the 2.0s cap.

Fallback frames are often unavailable (hot-stream instability) and are 640×360, so of low recognition value. Spending budget on the one high-resolution frame beats preserving time for retries that frequently cannot happen or cannot succeed.

Note that requests' read timeout is **time-to-next-byte of the response**, not a total call budget — so this specifically tolerates slower API *processing*, and does not permit an unbounded hang. All existing invariants hold: the deadline math is untouched, `_run_ocr_bounded` still enforces the hard deadline via `_OcrDeadlineExceeded`, and the activation guard is unchanged. Because `read` is `min(cap, remaining - connect)`, the widened cap only engages when `remaining > 3.0s` — i.e. the first attempt of a 4s budget. Tests assert a 3.0s budget still yields `(1.0, 2.0)`.

The 4s decision budget continues to bound the whole event; nothing here can extend it.

## Production behaviour change

- Denials still read `ocr_error` in the UI and in D1 — no dashboard, contract, or migration change is required.
- The journal now names the cause, so the next drive-through's trace shows whether Plate Recognizer was rate-limiting, erroring, or unreachable.
- Slow-but-successful OCR calls up to ~2.8s of API processing on the first frame now succeed instead of being denied.

## Risk

Widening the first read window trades a retry for a longer first attempt. An event where the first call hangs to 2.8s now has ~0.2s left, so it reaches `decision_timeout` instead of retrying frame 2 and reporting `ocr_error`. That is the intended trade given fallback frames are usually absent or low-value, and both outcomes are already fail-closed denials. The new cause labels make this directly measurable in the journal if it needs revisiting.

## Testing

`python -m unittest discover -s tests` — **662 tests, all passing** (3 pre-existing skips), up from 634 on `master`. Verified on Python 3.12 and 3.13; CI covers 3.10 and 3.11. `python -m compileall -q gate_controller deployment tests` passes.

All 634 pre-existing tests pass **unmodified**, which is itself the evidence that the wire format and exception categories are unchanged. New coverage: every cause classification, `http_<status>` bounding, network-vs-API separation, wire-format stability with and without a cause, no body/credential/path in any log line, the fail-safe paths, and the first-vs-subsequent read cap.

Relates to #64 — its required evidence includes "OCR start/end and every candidate", and these cause labels are what make the next drive-through's trace diagnostic. Relates to #43. Closes neither.

No relay, actuation, or matching logic was touched, and no `GATE_` environment default was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR error handling across closed requests, network failures, service errors, invalid responses, and confidence issues.
  * Added bounded OCR timeouts to prevent processing from waiting indefinitely.
  * Preserved original transport errors for more reliable troubleshooting.

* **Observability**
  * Added privacy-safe failure classification to internal diagnostics and journals.
  * Sensitive data, credentials, response contents, and recognition details are excluded from failure logs.
  * Existing event notifications and transmitted telemetry formats remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->